### PR TITLE
Gmail integration enhancements: contact discovery and broker support

### DIFF
--- a/app/Http/Controllers/ActiveCustomersController.php
+++ b/app/Http/Controllers/ActiveCustomersController.php
@@ -2,9 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\FulfilBrokerContact;
 use App\Models\FulfilContactMetadata;
 use App\Models\FulfilCustomerMetadata;
+use App\Models\FulfilUncategorizedContact;
 use App\Services\FulfilService;
+use Illuminate\Http\JsonResponse;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -101,12 +104,60 @@ class ActiveCustomersController extends Controller
             }
         }
 
-        // Merge in local metadata (company_urls for Gmail matching)
+        // Merge in local metadata (company_urls for Gmail matching, broker info)
         $localMetadata = FulfilCustomerMetadata::find($id);
         $customer['company_urls'] = $localMetadata?->company_urls ?? [];
+        $customer['broker'] = $localMetadata?->broker ?? false;
+        $customer['broker_commission'] = $localMetadata?->broker_commission;
+        $customer['broker_company_name'] = $localMetadata?->broker_company_name;
+
+        // Get broker contacts
+        $brokerContacts = FulfilBrokerContact::where('fulfil_party_id', $id)->get()->map(fn($c) => [
+            'id' => $c->id,
+            'name' => $c->name,
+            'email' => $c->email,
+            'last_emailed_at' => $c->last_emailed_at?->toIso8601String(),
+            'last_received_at' => $c->last_received_at?->toIso8601String(),
+        ])->toArray();
 
         // Merge email tracking dates into buyer contacts
         $buyerContacts = $this->mergeContactEmailMetadata($id, $customer['buyers'] ?? []);
+
+        // Get local contacts (discovered from emails)
+        $localContacts = FulfilUncategorizedContact::where('fulfil_party_id', $id)->get();
+
+        // Separate uncategorized from categorized local contacts
+        $uncategorizedContacts = $localContacts->whereNull('type')->map(fn($c) => [
+            'id' => $c->id,
+            'name' => $c->name,
+            'email' => $c->email,
+            'last_emailed_at' => $c->last_emailed_at?->toIso8601String(),
+            'last_received_at' => $c->last_received_at?->toIso8601String(),
+        ])->values()->toArray();
+
+        // Merge categorized local contacts with Fulfil contacts
+        $localBuyers = $localContacts->where('type', 'buyer')->map(fn($c) => [
+            'id' => $c->id,
+            'name' => $c->name,
+            'email' => $c->email,
+            'is_local' => true,
+            'last_emailed_at' => $c->last_emailed_at?->toIso8601String(),
+            'last_received_at' => $c->last_received_at?->toIso8601String(),
+        ])->values()->toArray();
+
+        $localAP = $localContacts->where('type', 'accounts_payable')->map(fn($c) => [
+            'id' => $c->id,
+            'name' => $c->name,
+            'email' => $c->email,
+            'is_local' => true,
+        ])->values()->toArray();
+
+        $localLogistics = $localContacts->where('type', 'logistics')->map(fn($c) => [
+            'id' => $c->id,
+            'name' => $c->name,
+            'email' => $c->email,
+            'is_local' => true,
+        ])->values()->toArray();
 
         // Calculate T12M monthly revenue
         $monthlyRevenue = $this->calculateMonthlyRevenue($salesOrders);
@@ -123,6 +174,11 @@ class ActiveCustomersController extends Controller
         return Inertia::render('ActiveCustomers/Show', [
             'customer' => $customer,
             'buyerContacts' => $buyerContacts,
+            'brokerContacts' => $brokerContacts,
+            'localBuyers' => $localBuyers,
+            'localAP' => $localAP,
+            'localLogistics' => $localLogistics,
+            'uncategorizedContacts' => $uncategorizedContacts,
             'monthlyRevenue' => $monthlyRevenue,
             'topProducts' => $topProducts,
             'upcomingOrders' => $upcomingOrders,
@@ -460,5 +516,321 @@ class ActiveCustomersController extends Controller
         $metadata->save();
 
         return back()->with('success', 'Company URLs updated successfully.');
+    }
+
+    /**
+     * Create a new local contact for a customer (uncategorized by default).
+     */
+    public function createLocalContact(Request $request, int $id): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => ['required', 'string', 'min:1', 'max:100'],
+            'email' => ['required', 'email', 'max:255'],
+            'type' => ['nullable', 'in:buyer,accounts_payable,logistics'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        // Ensure customer metadata exists
+        FulfilCustomerMetadata::findOrCreateForCustomer($id);
+
+        // Check if contact with this email already exists
+        $existing = FulfilUncategorizedContact::where('fulfil_party_id', $id)
+            ->whereRaw('LOWER(email) = ?', [strtolower($request->email)])
+            ->first();
+
+        if ($existing) {
+            return response()->json([
+                'message' => 'A contact with this email already exists',
+            ], 422);
+        }
+
+        $contact = FulfilUncategorizedContact::create([
+            'fulfil_party_id' => $id,
+            'name' => $request->name,
+            'email' => strtolower($request->email),
+            'type' => $request->type,
+        ]);
+
+        return response()->json([
+            'message' => 'Contact created successfully',
+            'contact' => [
+                'id' => $contact->id,
+                'name' => $contact->name,
+                'email' => $contact->email,
+                'type' => $contact->type,
+            ],
+        ]);
+    }
+
+    /**
+     * Update a local contact for a customer.
+     */
+    public function updateLocalContact(Request $request, int $customerId, int $contactId): JsonResponse
+    {
+        $contact = FulfilUncategorizedContact::where('fulfil_party_id', $customerId)
+            ->where('id', $contactId)
+            ->firstOrFail();
+
+        $validator = Validator::make($request->all(), [
+            'name' => ['sometimes', 'string', 'min:1', 'max:100'],
+            'email' => ['sometimes', 'email', 'max:255'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $updateData = [];
+        if ($request->has('name')) {
+            $updateData['name'] = $request->name;
+        }
+        if ($request->has('email')) {
+            $updateData['email'] = strtolower($request->email);
+        }
+
+        if (!empty($updateData)) {
+            $contact->update($updateData);
+        }
+
+        return response()->json([
+            'message' => 'Contact updated successfully',
+            'contact' => [
+                'id' => $contact->id,
+                'name' => $contact->name,
+                'email' => $contact->email,
+                'type' => $contact->type,
+            ],
+        ]);
+    }
+
+    /**
+     * Delete a local contact for a customer.
+     */
+    public function deleteLocalContact(int $customerId, int $contactId): JsonResponse
+    {
+        $contact = FulfilUncategorizedContact::where('fulfil_party_id', $customerId)
+            ->where('id', $contactId)
+            ->firstOrFail();
+
+        $contact->delete();
+
+        return response()->json([
+            'message' => 'Contact deleted successfully',
+        ]);
+    }
+
+    /**
+     * Categorize an uncategorized local contact.
+     */
+    public function categorizeContact(Request $request, int $customerId, int $contactId): JsonResponse
+    {
+        $contact = FulfilUncategorizedContact::where('fulfil_party_id', $customerId)
+            ->where('id', $contactId)
+            ->firstOrFail();
+
+        // Only allow categorization of uncategorized contacts (type = null)
+        if ($contact->type !== null) {
+            return response()->json([
+                'message' => 'Only uncategorized contacts can be categorized',
+            ], 422);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'type' => ['required', 'in:buyer,accounts_payable,logistics'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Invalid contact type',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $contact->update(['type' => $request->type]);
+
+        return response()->json([
+            'message' => 'Contact categorized successfully',
+            'contact' => [
+                'id' => $contact->id,
+                'name' => $contact->name,
+                'email' => $contact->email,
+                'type' => $contact->type,
+            ],
+        ]);
+    }
+
+    /**
+     * Update broker settings for a customer.
+     */
+    public function updateBroker(Request $request, int $id): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'broker' => ['required', 'boolean'],
+            'broker_commission' => ['nullable', 'numeric', 'min:0', 'max:100'],
+            'broker_company_name' => ['nullable', 'string', 'max:255'],
+            'broker_contacts' => ['nullable', 'array'],
+            'broker_contacts.*.name' => ['required', 'string', 'min:1', 'max:100'],
+            'broker_contacts.*.email' => ['nullable', 'email', 'max:255'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $metadata = FulfilCustomerMetadata::findOrCreateForCustomer($id);
+        $metadata->broker = $request->broker;
+        $metadata->broker_commission = $request->broker_commission;
+        $metadata->broker_company_name = $request->broker_company_name;
+        $metadata->save();
+
+        // Update broker contacts if provided
+        if ($request->has('broker_contacts')) {
+            // Delete existing broker contacts for this customer
+            FulfilBrokerContact::where('fulfil_party_id', $id)->delete();
+
+            // Create new broker contacts
+            $contacts = $request->broker_contacts ?? [];
+            foreach ($contacts as $contactData) {
+                if (!empty($contactData['name'])) {
+                    FulfilBrokerContact::create([
+                        'fulfil_party_id' => $id,
+                        'name' => $contactData['name'],
+                        'email' => strtolower($contactData['email'] ?? ''),
+                    ]);
+                }
+            }
+        }
+
+        // TODO: Sync to Fulfil metafields
+
+        return response()->json([
+            'message' => 'Broker settings updated successfully',
+            'broker' => $metadata->broker,
+            'broker_commission' => $metadata->broker_commission,
+        ]);
+    }
+
+    /**
+     * Create a broker contact for a customer.
+     */
+    public function createBrokerContact(Request $request, int $id): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => ['required', 'string', 'min:1', 'max:100'],
+            'email' => ['required', 'email', 'max:255'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        // Ensure customer metadata exists
+        FulfilCustomerMetadata::findOrCreateForCustomer($id);
+
+        // Check if contact with this email already exists
+        $existing = FulfilBrokerContact::where('fulfil_party_id', $id)
+            ->whereRaw('LOWER(email) = ?', [strtolower($request->email)])
+            ->first();
+
+        if ($existing) {
+            return response()->json([
+                'message' => 'A broker contact with this email already exists',
+            ], 422);
+        }
+
+        $contact = FulfilBrokerContact::create([
+            'fulfil_party_id' => $id,
+            'name' => $request->name,
+            'email' => strtolower($request->email),
+        ]);
+
+        // TODO: Sync to Fulfil contacts with "Broker: Name" format
+
+        return response()->json([
+            'message' => 'Broker contact created successfully',
+            'contact' => [
+                'id' => $contact->id,
+                'name' => $contact->name,
+                'email' => $contact->email,
+            ],
+        ]);
+    }
+
+    /**
+     * Update a broker contact for a customer.
+     */
+    public function updateBrokerContact(Request $request, int $customerId, int $contactId): JsonResponse
+    {
+        $contact = FulfilBrokerContact::where('fulfil_party_id', $customerId)
+            ->where('id', $contactId)
+            ->firstOrFail();
+
+        $validator = Validator::make($request->all(), [
+            'name' => ['sometimes', 'string', 'min:1', 'max:100'],
+            'email' => ['sometimes', 'email', 'max:255'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $updateData = [];
+        if ($request->has('name')) {
+            $updateData['name'] = $request->name;
+        }
+        if ($request->has('email')) {
+            $updateData['email'] = strtolower($request->email);
+        }
+
+        if (!empty($updateData)) {
+            $contact->update($updateData);
+        }
+
+        // TODO: Sync to Fulfil contacts
+
+        return response()->json([
+            'message' => 'Broker contact updated successfully',
+            'contact' => [
+                'id' => $contact->id,
+                'name' => $contact->name,
+                'email' => $contact->email,
+            ],
+        ]);
+    }
+
+    /**
+     * Delete a broker contact for a customer.
+     */
+    public function deleteBrokerContact(int $customerId, int $contactId): JsonResponse
+    {
+        $contact = FulfilBrokerContact::where('fulfil_party_id', $customerId)
+            ->where('id', $contactId)
+            ->firstOrFail();
+
+        $contact->delete();
+
+        // TODO: Remove from Fulfil contacts
+
+        return response()->json([
+            'message' => 'Broker contact deleted successfully',
+        ]);
     }
 }

--- a/app/Http/Controllers/ProspectController.php
+++ b/app/Http/Controllers/ProspectController.php
@@ -186,7 +186,7 @@ class ProspectController extends Controller
      */
     public function show(int $id): Response
     {
-        $prospect = Prospect::with(['buyers', 'accountsPayable', 'logistics', 'products'])->findOrFail($id);
+        $prospect = Prospect::with(['buyers', 'accountsPayable', 'logistics', 'uncategorized', 'brokerContacts', 'products'])->findOrFail($id);
 
         // Get all products for the dropdown
         $products = $this->fulfil->getProducts();
@@ -222,6 +222,16 @@ class ProspectController extends Controller
                 'shelf_life_requirement' => $prospect->shelf_life_requirement,
                 'vendor_guide' => $prospect->vendor_guide,
                 'company_urls' => $prospect->company_urls ?? [],
+                'broker' => $prospect->broker ?? false,
+                'broker_commission' => $prospect->broker_commission,
+                'broker_company_name' => $prospect->broker_company_name,
+                'broker_contacts' => $prospect->brokerContacts->map(fn($c) => [
+                    'id' => $c->id,
+                    'name' => $c->name,
+                    'value' => $c->value,
+                    'last_emailed_at' => $c->last_emailed_at?->toIso8601String(),
+                    'last_received_at' => $c->last_received_at?->toIso8601String(),
+                ])->toArray(),
                 'buyers' => $prospect->buyers->map(fn($c) => [
                     'id' => $c->id,
                     'name' => $c->name,
@@ -238,6 +248,13 @@ class ProspectController extends Controller
                     'id' => $c->id,
                     'name' => $c->name,
                     'value' => $c->value,
+                ])->toArray(),
+                'uncategorized' => $prospect->uncategorized->map(fn($c) => [
+                    'id' => $c->id,
+                    'name' => $c->name,
+                    'value' => $c->value,
+                    'last_emailed_at' => $c->last_emailed_at?->toIso8601String(),
+                    'last_received_at' => $c->last_received_at?->toIso8601String(),
                 ])->toArray(),
                 'products' => $prospectProducts,
                 'product_ids' => $prospect->products->pluck('product_id')->toArray(),
@@ -269,6 +286,12 @@ class ProspectController extends Controller
             'vendor_guide' => ['nullable', 'string', 'max:500', 'url'],
             'company_urls' => ['sometimes', 'array'],
             'company_urls.*' => ['string', 'max:255'],
+            'broker' => ['sometimes', 'boolean'],
+            'broker_commission' => ['nullable', 'numeric', 'min:0', 'max:100'],
+            'broker_company_name' => ['nullable', 'string', 'max:255'],
+            'broker_contacts' => ['sometimes', 'array'],
+            'broker_contacts.*.name' => ['required_with:broker_contacts', 'string', 'min:1', 'max:100'],
+            'broker_contacts.*.value' => ['nullable', 'email', 'max:255'],
             'buyers' => ['sometimes', 'array'],
             'buyers.*.name' => ['required_with:buyers', 'string', 'min:1', 'max:100'],
             'buyers.*.value' => ['nullable', 'email', 'max:255'],
@@ -278,6 +301,9 @@ class ProspectController extends Controller
             'logistics' => ['sometimes', 'array'],
             'logistics.*.name' => ['required_with:logistics', 'string', 'min:1', 'max:100'],
             'logistics.*.value' => ['nullable', 'email', 'max:255'],
+            'uncategorized' => ['sometimes', 'array'],
+            'uncategorized.*.name' => ['required_with:uncategorized', 'string', 'min:1', 'max:100'],
+            'uncategorized.*.value' => ['nullable', 'email', 'max:255'],
             'product_ids' => ['sometimes', 'array'],
             'product_ids.*' => ['integer'],
         ], [
@@ -287,6 +313,10 @@ class ProspectController extends Controller
             'accounts_payable.*.name.required_with' => 'AP contact name is required.',
             'logistics.*.name.required_with' => 'Logistics contact name is required.',
             'logistics.*.value.email' => 'Please enter a valid email address.',
+            'uncategorized.*.name.required_with' => 'Contact name is required.',
+            'uncategorized.*.value.email' => 'Please enter a valid email address.',
+            'broker_contacts.*.name.required_with' => 'Broker contact name is required.',
+            'broker_contacts.*.value.email' => 'Please enter a valid email address for broker contact.',
             'vendor_guide.url' => 'Please enter a valid URL.',
         ]);
 
@@ -329,6 +359,15 @@ class ProspectController extends Controller
                 }
                 if (array_key_exists('company_urls', $validated)) {
                     $updateData['company_urls'] = array_values(array_filter($validated['company_urls']));
+                }
+                if (array_key_exists('broker', $validated)) {
+                    $updateData['broker'] = $validated['broker'];
+                }
+                if (array_key_exists('broker_commission', $validated)) {
+                    $updateData['broker_commission'] = $validated['broker_commission'];
+                }
+                if (array_key_exists('broker_company_name', $validated)) {
+                    $updateData['broker_company_name'] = $validated['broker_company_name'];
                 }
                 if (!empty($updateData)) {
                     $prospect->update($updateData);
@@ -382,6 +421,36 @@ class ProspectController extends Controller
                     }
                 }
 
+                // Update uncategorized contacts if provided
+                if (isset($validated['uncategorized'])) {
+                    $prospect->uncategorized()->delete();
+                    foreach ($validated['uncategorized'] as $contact) {
+                        if (!empty($contact['name'])) {
+                            ProspectContact::create([
+                                'prospect_id' => $prospect->id,
+                                'type' => ProspectContact::TYPE_UNCATEGORIZED,
+                                'name' => $contact['name'],
+                                'value' => $contact['value'] ?? null,
+                            ]);
+                        }
+                    }
+                }
+
+                // Update broker contacts if provided
+                if (isset($validated['broker_contacts'])) {
+                    $prospect->brokerContacts()->delete();
+                    foreach ($validated['broker_contacts'] as $contact) {
+                        if (!empty($contact['name'])) {
+                            ProspectContact::create([
+                                'prospect_id' => $prospect->id,
+                                'type' => ProspectContact::TYPE_BROKER,
+                                'name' => $contact['name'],
+                                'value' => $contact['value'] ?? null,
+                            ]);
+                        }
+                    }
+                }
+
                 // Update products if provided
                 if (isset($validated['product_ids'])) {
                     // Delete existing and recreate
@@ -412,7 +481,7 @@ class ProspectController extends Controller
      */
     protected function autoAddDomainsFromContacts(Prospect $prospect, array $validated): void
     {
-        $contactTypes = ['buyers', 'accounts_payable', 'logistics'];
+        $contactTypes = ['buyers', 'accounts_payable', 'logistics', 'uncategorized'];
         $newDomains = [];
 
         foreach ($contactTypes as $type) {
@@ -442,5 +511,46 @@ class ProspectController extends Controller
                 }
             }
         }
+    }
+
+    /**
+     * Categorize an uncategorized contact.
+     */
+    public function categorizeContact(Request $request, int $prospectId, int $contactId): JsonResponse
+    {
+        $prospect = Prospect::findOrFail($prospectId);
+        $contact = ProspectContact::where('prospect_id', $prospectId)
+            ->where('id', $contactId)
+            ->firstOrFail();
+
+        // Only allow categorization of uncategorized contacts
+        if ($contact->type !== ProspectContact::TYPE_UNCATEGORIZED) {
+            return response()->json([
+                'message' => 'Only uncategorized contacts can be categorized',
+            ], 422);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'type' => ['required', 'in:buyer,accounts_payable,logistics'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Invalid contact type',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $contact->update(['type' => $request->type]);
+
+        return response()->json([
+            'message' => 'Contact categorized successfully',
+            'contact' => [
+                'id' => $contact->id,
+                'name' => $contact->name,
+                'value' => $contact->value,
+                'type' => $contact->type,
+            ],
+        ]);
     }
 }

--- a/app/Models/FulfilBrokerContact.php
+++ b/app/Models/FulfilBrokerContact.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FulfilBrokerContact extends Model
+{
+    protected $table = 'fulfil_broker_contacts';
+
+    protected $fillable = [
+        'fulfil_party_id',
+        'name',
+        'email',
+        'last_emailed_at',
+        'last_received_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'last_emailed_at' => 'datetime',
+            'last_received_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * Get the customer metadata this contact belongs to.
+     */
+    public function customerMetadata(): BelongsTo
+    {
+        return $this->belongsTo(FulfilCustomerMetadata::class, 'fulfil_party_id', 'fulfil_party_id');
+    }
+
+    /**
+     * Get or create a broker contact for a customer.
+     */
+    public static function findOrCreateForContact(int $fulfilPartyId, string $email, string $name = ''): self
+    {
+        return self::firstOrCreate(
+            [
+                'fulfil_party_id' => $fulfilPartyId,
+                'email' => strtolower($email),
+            ],
+            [
+                'name' => $name,
+            ]
+        );
+    }
+
+    /**
+     * Record that an email was sent to this contact.
+     */
+    public function recordEmailSent(\DateTime $date): void
+    {
+        if (!$this->last_emailed_at || $date > $this->last_emailed_at) {
+            $this->last_emailed_at = $date;
+            $this->save();
+        }
+    }
+
+    /**
+     * Record that an email was received from this contact.
+     */
+    public function recordEmailReceived(\DateTime $date): void
+    {
+        if (!$this->last_received_at || $date > $this->last_received_at) {
+            $this->last_received_at = $date;
+            $this->save();
+        }
+    }
+
+    /**
+     * Format the name for Fulfil sync (with "Broker: " prefix).
+     */
+    public function getFulfilName(): string
+    {
+        return 'Broker: ' . $this->name;
+    }
+
+    /**
+     * Parse a Fulfil contact name to extract the broker name.
+     */
+    public static function parseFulfilName(string $fulfilName): ?string
+    {
+        if (str_starts_with($fulfilName, 'Broker: ')) {
+            return substr($fulfilName, 8); // Remove "Broker: " prefix
+        }
+        return null;
+    }
+}

--- a/app/Models/FulfilCustomerMetadata.php
+++ b/app/Models/FulfilCustomerMetadata.php
@@ -24,12 +24,17 @@ class FulfilCustomerMetadata extends Model
     protected $fillable = [
         'fulfil_party_id',
         'company_urls',
+        'broker',
+        'broker_commission',
+        'broker_company_name',
     ];
 
     protected function casts(): array
     {
         return [
             'company_urls' => 'array',
+            'broker' => 'boolean',
+            'broker_commission' => 'decimal:2',
         ];
     }
 
@@ -97,5 +102,21 @@ class FulfilCustomerMetadata extends Model
     public function contactMetadata()
     {
         return $this->hasMany(FulfilContactMetadata::class, 'fulfil_party_id', 'fulfil_party_id');
+    }
+
+    /**
+     * Get uncategorized contacts for this customer.
+     */
+    public function uncategorizedContacts()
+    {
+        return $this->hasMany(FulfilUncategorizedContact::class, 'fulfil_party_id', 'fulfil_party_id');
+    }
+
+    /**
+     * Get broker contacts for this customer.
+     */
+    public function brokerContacts()
+    {
+        return $this->hasMany(FulfilBrokerContact::class, 'fulfil_party_id', 'fulfil_party_id');
     }
 }

--- a/app/Models/FulfilUncategorizedContact.php
+++ b/app/Models/FulfilUncategorizedContact.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FulfilUncategorizedContact extends Model
+{
+    protected $table = 'fulfil_uncategorized_contacts';
+
+    const TYPE_BUYER = 'buyer';
+    const TYPE_ACCOUNTS_PAYABLE = 'accounts_payable';
+    const TYPE_LOGISTICS = 'logistics';
+
+    /**
+     * Contact types that can be assigned.
+     */
+    const CATEGORIZABLE_TYPES = [
+        self::TYPE_BUYER,
+        self::TYPE_ACCOUNTS_PAYABLE,
+        self::TYPE_LOGISTICS,
+    ];
+
+    protected $fillable = [
+        'fulfil_party_id',
+        'name',
+        'email',
+        'type',
+        'last_emailed_at',
+        'last_received_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'last_emailed_at' => 'datetime',
+            'last_received_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * Get the customer metadata this contact belongs to.
+     */
+    public function customerMetadata(): BelongsTo
+    {
+        return $this->belongsTo(FulfilCustomerMetadata::class, 'fulfil_party_id', 'fulfil_party_id');
+    }
+
+    /**
+     * Get or create an uncategorized contact for a customer email.
+     */
+    public static function findOrCreateForContact(int $fulfilPartyId, string $email): self
+    {
+        return self::firstOrCreate(
+            [
+                'fulfil_party_id' => $fulfilPartyId,
+                'email' => strtolower($email),
+            ],
+            [
+                'name' => '',
+            ]
+        );
+    }
+
+    /**
+     * Record that an email was sent to this contact.
+     */
+    public function recordEmailSent(\DateTime $date): void
+    {
+        if (!$this->last_emailed_at || $date > $this->last_emailed_at) {
+            $this->last_emailed_at = $date;
+            $this->save();
+        }
+    }
+
+    /**
+     * Record that an email was received from this contact.
+     */
+    public function recordEmailReceived(\DateTime $date): void
+    {
+        if (!$this->last_received_at || $date > $this->last_received_at) {
+            $this->last_received_at = $date;
+            $this->save();
+        }
+    }
+
+    /**
+     * Get the email domain from this contact's email.
+     */
+    public function getEmailDomain(): ?string
+    {
+        if (empty($this->email)) {
+            return null;
+        }
+        $parts = explode('@', $this->email);
+        return count($parts) === 2 ? strtolower($parts[1]) : null;
+    }
+}

--- a/app/Models/Prospect.php
+++ b/app/Models/Prospect.php
@@ -52,6 +52,9 @@ class Prospect extends Model
         'shelf_life_requirement',
         'vendor_guide',
         'company_urls',
+        'broker',
+        'broker_commission',
+        'broker_company_name',
     ];
 
     protected function casts(): array
@@ -60,6 +63,8 @@ class Prospect extends Model
             'created_at' => 'datetime',
             'updated_at' => 'datetime',
             'company_urls' => 'array',
+            'broker' => 'boolean',
+            'broker_commission' => 'decimal:2',
         ];
     }
 
@@ -163,6 +168,22 @@ class Prospect extends Model
     public function logistics(): HasMany
     {
         return $this->hasMany(ProspectContact::class)->where('type', 'logistics');
+    }
+
+    /**
+     * Get uncategorized contacts for this prospect.
+     */
+    public function uncategorized(): HasMany
+    {
+        return $this->hasMany(ProspectContact::class)->where('type', 'uncategorized');
+    }
+
+    /**
+     * Get broker contacts for this prospect.
+     */
+    public function brokerContacts(): HasMany
+    {
+        return $this->hasMany(ProspectContact::class)->where('type', 'broker');
     }
 
     /**

--- a/app/Models/ProspectContact.php
+++ b/app/Models/ProspectContact.php
@@ -13,6 +13,17 @@ class ProspectContact extends Model
     const TYPE_BUYER = 'buyer';
     const TYPE_ACCOUNTS_PAYABLE = 'accounts_payable';
     const TYPE_LOGISTICS = 'logistics';
+    const TYPE_UNCATEGORIZED = 'uncategorized';
+    const TYPE_BROKER = 'broker';
+
+    /**
+     * Contact types that can be assigned by categorization.
+     */
+    const CATEGORIZABLE_TYPES = [
+        self::TYPE_BUYER,
+        self::TYPE_ACCOUNTS_PAYABLE,
+        self::TYPE_LOGISTICS,
+    ];
 
     protected $fillable = [
         'prospect_id',

--- a/app/Services/FulfilService.php
+++ b/app/Services/FulfilService.php
@@ -282,6 +282,8 @@ class FulfilService
             'buyers' => [],
             'accounts_payable' => [],
             'logistics' => [],
+            'broker_contacts_from_fulfil' => [],  // Broker contacts parsed from Fulfil
+            'broker_company_name_from_fulfil' => null,  // Extracted from broker contact names
             'shelf_life_requirement' => null,
             'vendor_guide' => null,
             'discount_percent' => null,
@@ -335,6 +337,23 @@ class FulfilService
                 $parsed['shelf_life_requirement'] = $dataValue;
             } elseif ($dataType === 'vendor_guide') {
                 $parsed['vendor_guide'] = $dataValue;
+            }
+            return;
+        }
+
+        // Broker contact: name = "Broker (Company Name): Contact Name"
+        // Pattern: starts with "Broker" followed by optional "(Company)" then ": Name"
+        if (preg_match('/^Broker\s*(?:\(([^)]+)\))?\s*:\s*(.+)$/i', $name, $matches)) {
+            $brokerCompany = trim($matches[1] ?? '');
+            $contactName = trim($matches[2]);
+            $isEmail = str_contains($value, '@') && str_contains($value, '.');
+
+            if ($isEmail) {
+                $parsed['broker_contacts_from_fulfil'][] = ['name' => $contactName, 'email' => $value];
+                // Extract broker company name from the first broker contact found
+                if (!empty($brokerCompany) && empty($parsed['broker_company_name_from_fulfil'])) {
+                    $parsed['broker_company_name_from_fulfil'] = $brokerCompany;
+                }
             }
             return;
         }
@@ -1098,6 +1117,21 @@ class FulfilService
             ];
         }
 
+        // Broker contacts (optional)
+        // Format: "Broker (Company Name): Contact Name"
+        $brokerCompanyName = $data['broker_company_name'] ?? '';
+        foreach ($data['broker_contacts'] ?? [] as $broker) {
+            $mechName = $brokerCompanyName
+                ? "Broker ({$brokerCompanyName}): {$broker['name']}"
+                : "Broker: {$broker['name']}";
+            $contactMechanisms[] = [
+                'party' => $partyId,
+                'type' => 'email',
+                'name' => $mechName,
+                'value' => $broker['email'],
+            ];
+        }
+
         // Shelf life requirement (required)
         // Using type 'email' so it's exposed to data warehouse
         $contactMechanisms[] = [
@@ -1244,6 +1278,7 @@ class FulfilService
         return isset($data['buyers'])
             || isset($data['accounts_payable'])
             || isset($data['logistics'])
+            || isset($data['broker_contacts'])
             || isset($data['shelf_life_requirement'])
             || isset($data['vendor_guide']);
     }
@@ -1373,6 +1408,57 @@ class FulfilService
             foreach ($existingLogistics as $el) {
                 if (!in_array($el['id'], $matchedIds)) {
                     $toDelete[] = $el['id'];
+                }
+            }
+        }
+
+        // Process broker contacts
+        // Format: "Broker (Company Name): Contact Name"
+        if (isset($data['broker_contacts'])) {
+            $brokerCompanyName = $data['broker_company_name'] ?? '';
+            $existingBrokers = array_filter($existing, fn($m) => preg_match('/^Broker\s*(?:\([^)]*\))?\s*:/i', $m['name'] ?? ''));
+
+            foreach ($data['broker_contacts'] as $broker) {
+                // Build mechanism name with company name if provided
+                $mechName = $brokerCompanyName
+                    ? "Broker ({$brokerCompanyName}): {$broker['name']}"
+                    : "Broker: {$broker['name']}";
+
+                // Try to find existing mechanism by contact name (ignore company name changes)
+                $found = null;
+                foreach ($existingBrokers as $eb) {
+                    // Extract contact name from existing mechanism
+                    if (preg_match('/^Broker\s*(?:\([^)]*\))?\s*:\s*(.+)$/i', $eb['name'], $matches)) {
+                        if (trim($matches[1]) === $broker['name']) {
+                            $found = $eb;
+                            break;
+                        }
+                    }
+                }
+
+                if ($found) {
+                    $matchedIds[] = $found['id'];
+                    // Update if email or company name changed
+                    if ($found['value'] !== $broker['email'] || $found['name'] !== $mechName) {
+                        $toUpdate[] = [
+                            'id' => $found['id'],
+                            'name' => $mechName,
+                            'value' => $broker['email'],
+                        ];
+                    }
+                } else {
+                    $toCreate[] = [
+                        'party' => $partyId,
+                        'type' => 'email',
+                        'name' => $mechName,
+                        'value' => $broker['email'],
+                    ];
+                }
+            }
+
+            foreach ($existingBrokers as $eb) {
+                if (!in_array($eb['id'], $matchedIds)) {
+                    $toDelete[] = $eb['id'];
                 }
             }
         }

--- a/app/Services/GmailService.php
+++ b/app/Services/GmailService.php
@@ -3,8 +3,10 @@
 namespace App\Services;
 
 use App\Models\Email;
+use App\Models\FulfilBrokerContact;
 use App\Models\FulfilContactMetadata;
 use App\Models\FulfilCustomerMetadata;
+use App\Models\FulfilUncategorizedContact;
 use App\Models\GmailSyncHistory;
 use App\Models\Prospect;
 use App\Models\ProspectContact;
@@ -164,22 +166,25 @@ class GmailService
             // Get all company domains (prospects + active customers) for filtering
             $companyDomains = $this->getAllCompanyDomains();
 
-            if (empty($companyDomains)) {
-                // No companies with domains to match
+            // Get all broker emails for exact email matching
+            $brokerEmails = $this->getAllBrokerEmails();
+
+            if (empty($companyDomains) && empty($brokerEmails)) {
+                // No companies with domains or broker emails to match
                 $syncHistory->markCompleted(0, 0);
                 return $syncHistory;
             }
 
-            // Fetch emails from Gmail, filtered by company domains
+            // Fetch emails from Gmail, filtered by company domains and broker emails
             $domains = array_keys($companyDomains);
-            $messages = $this->fetchMessagesForDomains($accessToken, $from, $now, $domains);
+            $messages = $this->fetchMessagesForDomainsAndEmails($accessToken, $from, $now, $domains, array_keys($brokerEmails));
             $fetched = count($messages);
             $matched = 0;
 
             foreach ($messages as $messageId) {
                 $emailData = $this->fetchMessageDetails($accessToken, $messageId);
 
-                if ($emailData && $this->processEmail($user, $emailData, $companyDomains)) {
+                if ($emailData && $this->processEmail($user, $emailData, $companyDomains, $brokerEmails)) {
                     $matched++;
                 }
             }
@@ -198,20 +203,16 @@ class GmailService
     }
 
     /**
-     * Fetch message IDs from Gmail filtered by prospect domains.
+     * Fetch message IDs from Gmail filtered by prospect domains and broker emails.
      *
-     * Batches domains to avoid query length limits and deduplicates results.
+     * Batches domains/emails to avoid query length limits and deduplicates results.
      */
-    protected function fetchMessagesForDomains(string $accessToken, Carbon $from, Carbon $to, array $domains): array
+    protected function fetchMessagesForDomainsAndEmails(string $accessToken, Carbon $from, Carbon $to, array $domains, array $brokerEmails = []): array
     {
-        if (empty($domains)) {
+        if (empty($domains) && empty($brokerEmails)) {
             return [];
         }
 
-        // Batch domains to avoid query length limits
-        // Each domain adds ~40 chars (from:@domain.com OR to:@domain.com OR)
-        // Safe batch size: ~30 domains per query
-        $domainBatches = array_chunk($domains, 30);
         $allMessages = [];
 
         $dateQuery = sprintf(
@@ -220,26 +221,55 @@ class GmailService
             $to->copy()->addDay()->format('Y/m/d')
         );
 
-        foreach ($domainBatches as $batchDomains) {
-            $domainQueries = [];
-            foreach ($batchDomains as $domain) {
-                // Match emails from OR to this domain
-                $domainQueries[] = "from:@{$domain}";
-                $domainQueries[] = "to:@{$domain}";
+        // Batch domains to avoid query length limits
+        // Each domain adds ~40 chars (from:@domain.com OR to:@domain.com OR)
+        // Safe batch size: ~30 domains per query
+        if (!empty($domains)) {
+            $domainBatches = array_chunk($domains, 30);
+
+            foreach ($domainBatches as $batchDomains) {
+                $domainQueries = [];
+                foreach ($batchDomains as $domain) {
+                    // Match emails from OR to this domain
+                    $domainQueries[] = "from:@{$domain}";
+                    $domainQueries[] = "to:@{$domain}";
+                }
+
+                // Build query: date range AND (domain1 OR domain2 OR ...)
+                // Using {} syntax for OR grouping in Gmail
+                $domainFilter = '{' . implode(' ', $domainQueries) . '}';
+                $query = "{$dateQuery} {$domainFilter}";
+
+                Log::debug('Gmail query (domains)', ['query' => $query, 'domains_in_batch' => count($batchDomains)]);
+
+                $batchMessages = $this->fetchMessagesWithQuery($accessToken, $query);
+                $allMessages = array_merge($allMessages, $batchMessages);
             }
-
-            // Build query: date range AND (domain1 OR domain2 OR ...)
-            // Using {} syntax for OR grouping in Gmail
-            $domainFilter = '{' . implode(' ', $domainQueries) . '}';
-            $query = "{$dateQuery} {$domainFilter}";
-
-            Log::debug('Gmail query', ['query' => $query, 'domains_in_batch' => count($batchDomains)]);
-
-            $batchMessages = $this->fetchMessagesWithQuery($accessToken, $query);
-            $allMessages = array_merge($allMessages, $batchMessages);
         }
 
-        // Deduplicate message IDs (in case of overlapping domain matches)
+        // Fetch broker emails by exact email address match
+        if (!empty($brokerEmails)) {
+            $emailBatches = array_chunk($brokerEmails, 20);
+
+            foreach ($emailBatches as $batchEmails) {
+                $emailQueries = [];
+                foreach ($batchEmails as $email) {
+                    // Match emails from OR to this exact email address
+                    $emailQueries[] = "from:{$email}";
+                    $emailQueries[] = "to:{$email}";
+                }
+
+                $emailFilter = '{' . implode(' ', $emailQueries) . '}';
+                $query = "{$dateQuery} {$emailFilter}";
+
+                Log::debug('Gmail query (broker emails)', ['query' => $query, 'emails_in_batch' => count($batchEmails)]);
+
+                $batchMessages = $this->fetchMessagesWithQuery($accessToken, $query);
+                $allMessages = array_merge($allMessages, $batchMessages);
+            }
+        }
+
+        // Deduplicate message IDs (in case of overlapping matches)
         return array_unique($allMessages);
     }
 
@@ -313,9 +343,9 @@ class GmailService
     }
 
     /**
-     * Process an email and store if it matches a company domain (prospect or customer).
+     * Process an email and store if it matches a company domain (prospect or customer) or broker email.
      */
-    protected function processEmail(User $user, array $emailData, array $companyDomains): bool
+    protected function processEmail(User $user, array $emailData, array $companyDomains, array $brokerEmails = []): bool
     {
         $headers = $this->parseHeaders($emailData['payload']['headers'] ?? []);
 
@@ -326,24 +356,6 @@ class GmailService
         // Determine all email addresses involved
         $allEmails = array_merge([$fromEmail], $toEmails, $ccEmails);
         $allEmails = array_filter($allEmails);
-
-        // Check if any email matches a company domain
-        $matchedDomain = null;
-        $matchedEmail = null;
-        $matchInfo = null;
-        foreach ($allEmails as $email) {
-            $domain = strtolower(explode('@', $email)[1] ?? '');
-            if (isset($companyDomains[$domain])) {
-                $matchedDomain = $domain;
-                $matchedEmail = $email;
-                $matchInfo = $companyDomains[$domain];
-                break;
-            }
-        }
-
-        if (!$matchedDomain || !$matchInfo) {
-            return false; // No match
-        }
 
         // Determine direction
         $userEmail = $user->gmailToken->gmail_email;
@@ -360,14 +372,101 @@ class GmailService
         // Check for attachments
         $attachments = $this->parseAttachments($emailData['payload']);
 
-        // Handle based on company type (prospect or customer)
-        if ($matchInfo['type'] === 'prospect') {
-            $this->processProspectEmail($user, $emailData, $matchInfo['id'], $matchedDomain, $matchedEmail, $direction, $fromEmail, $toEmails, $ccEmails, $body, $emailDate, $attachments, $headers);
-        } else {
-            $this->processCustomerEmail($user, $emailData, $matchInfo['id'], $matchedDomain, $matchedEmail, $direction, $fromEmail, $toEmails, $ccEmails, $body, $emailDate, $attachments, $headers);
+        $processed = false;
+
+        // First, check for broker email matches (exact email match, takes priority)
+        foreach ($allEmails as $email) {
+            $emailLower = strtolower($email);
+            if (isset($brokerEmails[$emailLower])) {
+                $brokerInfo = $brokerEmails[$emailLower];
+                $this->processBrokerEmail($user, $emailData, $brokerInfo, $emailLower, $direction, $fromEmail, $toEmails, $ccEmails, $body, $emailDate, $attachments, $headers);
+                $processed = true;
+                // Don't break - a broker email might be linked to multiple entities
+            }
         }
 
-        return true;
+        // Then check for company domain matches
+        $matchedDomain = null;
+        $matchedEmail = null;
+        $matchInfo = null;
+        foreach ($allEmails as $email) {
+            $domain = strtolower(explode('@', $email)[1] ?? '');
+            if (isset($companyDomains[$domain])) {
+                $matchedDomain = $domain;
+                $matchedEmail = $email;
+                $matchInfo = $companyDomains[$domain];
+                break;
+            }
+        }
+
+        if ($matchedDomain && $matchInfo) {
+            // Handle based on company type (prospect or customer)
+            if ($matchInfo['type'] === 'prospect') {
+                $this->processProspectEmail($user, $emailData, $matchInfo['id'], $matchedDomain, $matchedEmail, $direction, $fromEmail, $toEmails, $ccEmails, $body, $emailDate, $attachments, $headers);
+            } else {
+                $this->processCustomerEmail($user, $emailData, $matchInfo['id'], $matchedDomain, $matchedEmail, $direction, $fromEmail, $toEmails, $ccEmails, $body, $emailDate, $attachments, $headers);
+            }
+            $processed = true;
+        }
+
+        return $processed;
+    }
+
+    /**
+     * Process an email for a broker contact.
+     * Updates email tracking for the broker contact without creating email records
+     * (the main email record is created by processProspectEmail or processCustomerEmail).
+     */
+    protected function processBrokerEmail(
+        User $user,
+        array $emailData,
+        array $brokerInfo,
+        string $brokerEmail,
+        string $direction,
+        string $fromEmail,
+        array $toEmails,
+        array $ccEmails,
+        array $body,
+        Carbon $emailDate,
+        array $attachments,
+        array $headers
+    ): void {
+        // Update email tracking for the broker contact
+        if ($brokerInfo['type'] === 'prospect') {
+            // Find the prospect broker contact
+            $contact = ProspectContact::where('prospect_id', $brokerInfo['id'])
+                ->where('type', ProspectContact::TYPE_BROKER)
+                ->whereRaw('LOWER(value) = ?', [$brokerEmail])
+                ->first();
+
+            if ($contact) {
+                if ($direction === Email::DIRECTION_OUTBOUND) {
+                    $contact->recordEmailSent($emailDate);
+                } else {
+                    $contact->recordEmailReceived($emailDate);
+                }
+            }
+        } else {
+            // Find or create the customer broker contact
+            $contact = FulfilBrokerContact::where('fulfil_party_id', $brokerInfo['id'])
+                ->whereRaw('LOWER(email) = ?', [$brokerEmail])
+                ->first();
+
+            if ($contact) {
+                if ($direction === Email::DIRECTION_OUTBOUND) {
+                    $contact->recordEmailSent($emailDate);
+                } else {
+                    $contact->recordEmailReceived($emailDate);
+                }
+            }
+        }
+
+        Log::debug('Processed broker email', [
+            'broker_email' => $brokerEmail,
+            'type' => $brokerInfo['type'],
+            'id' => $brokerInfo['id'],
+            'direction' => $direction,
+        ]);
     }
 
     /**
@@ -422,6 +521,61 @@ class GmailService
                 $contact->recordEmailReceived($emailDate);
             }
         }
+
+        // Discover new contacts from this email
+        $this->discoverProspectContacts($prospectId, $matchedDomain, $fromEmail, $toEmails, $ccEmails, $direction, $emailDate);
+    }
+
+    /**
+     * Discover new uncategorized contacts from email addresses for a prospect.
+     */
+    protected function discoverProspectContacts(
+        int $prospectId,
+        string $matchedDomain,
+        string $fromEmail,
+        array $toEmails,
+        array $ccEmails,
+        string $direction,
+        Carbon $emailDate
+    ): void {
+        // Collect all emails that match the prospect's domain
+        $allEmails = array_merge([$fromEmail], $toEmails, $ccEmails);
+        $allEmails = array_filter($allEmails);
+        $allEmails = array_unique(array_map('strtolower', $allEmails));
+
+        foreach ($allEmails as $email) {
+            $emailDomain = strtolower(explode('@', $email)[1] ?? '');
+            if ($emailDomain !== $matchedDomain) {
+                continue; // Not from the company domain
+            }
+
+            // Check if this email already exists as a contact
+            $existingContact = ProspectContact::where('prospect_id', $prospectId)
+                ->whereRaw('LOWER(value) = ?', [$email])
+                ->first();
+
+            if (!$existingContact) {
+                // Create uncategorized contact
+                $newContact = ProspectContact::create([
+                    'prospect_id' => $prospectId,
+                    'type' => ProspectContact::TYPE_UNCATEGORIZED,
+                    'name' => $this->extractName($email) ?? '',
+                    'value' => $email,
+                ]);
+
+                // Update email tracking for the new contact
+                if ($direction === Email::DIRECTION_OUTBOUND) {
+                    $newContact->recordEmailSent($emailDate);
+                } else {
+                    $newContact->recordEmailReceived($emailDate);
+                }
+
+                Log::info('Discovered new prospect contact', [
+                    'prospect_id' => $prospectId,
+                    'email' => $email,
+                ]);
+            }
+        }
     }
 
     /**
@@ -471,6 +625,69 @@ class GmailService
         } else {
             $contactMetadata->recordEmailReceived($emailDate);
         }
+
+        // Discover new contacts from this email
+        $this->discoverCustomerContacts($fulfilPartyId, $matchedDomain, $fromEmail, $toEmails, $ccEmails, $direction, $emailDate);
+    }
+
+    /**
+     * Discover new uncategorized contacts from email addresses for a customer.
+     */
+    protected function discoverCustomerContacts(
+        int $fulfilPartyId,
+        string $matchedDomain,
+        string $fromEmail,
+        array $toEmails,
+        array $ccEmails,
+        string $direction,
+        Carbon $emailDate
+    ): void {
+        // Collect all emails that match the customer's domain
+        $allEmails = array_merge([$fromEmail], $toEmails, $ccEmails);
+        $allEmails = array_filter($allEmails);
+        $allEmails = array_unique(array_map('strtolower', $allEmails));
+
+        // Get existing contact emails from FulfilContactMetadata (tracks known contacts from Fulfil)
+        $existingContactEmails = FulfilContactMetadata::where('fulfil_party_id', $fulfilPartyId)
+            ->pluck('email')
+            ->map(fn($e) => strtolower($e))
+            ->toArray();
+
+        // Get existing uncategorized contact emails
+        $existingUncategorizedEmails = FulfilUncategorizedContact::where('fulfil_party_id', $fulfilPartyId)
+            ->pluck('email')
+            ->map(fn($e) => strtolower($e))
+            ->toArray();
+
+        $knownEmails = array_merge($existingContactEmails, $existingUncategorizedEmails);
+
+        foreach ($allEmails as $email) {
+            $emailDomain = strtolower(explode('@', $email)[1] ?? '');
+            if ($emailDomain !== $matchedDomain) {
+                continue; // Not from the company domain
+            }
+
+            if (!in_array($email, $knownEmails)) {
+                // Create uncategorized contact
+                $newContact = FulfilUncategorizedContact::create([
+                    'fulfil_party_id' => $fulfilPartyId,
+                    'name' => '',
+                    'email' => $email,
+                ]);
+
+                // Update email tracking for the new contact
+                if ($direction === Email::DIRECTION_OUTBOUND) {
+                    $newContact->recordEmailSent($emailDate);
+                } else {
+                    $newContact->recordEmailReceived($emailDate);
+                }
+
+                Log::info('Discovered new customer contact', [
+                    'fulfil_party_id' => $fulfilPartyId,
+                    'email' => $email,
+                ]);
+            }
+        }
     }
 
     /**
@@ -508,6 +725,50 @@ class GmailService
         }
 
         return $domains;
+    }
+
+    /**
+     * Get all broker email addresses mapped to their entity info.
+     *
+     * Returns: ['broker@email.com' => ['type' => 'prospect'|'customer', 'id' => int], ...]
+     *
+     * Note: We match broker emails exactly (not by domain) to avoid pulling in
+     * all emails from a broker company when they represent multiple retailers.
+     */
+    protected function getAllBrokerEmails(): array
+    {
+        $emails = [];
+
+        // Get prospect broker contacts
+        $prospectBrokerContacts = ProspectContact::where('type', ProspectContact::TYPE_BROKER)
+            ->whereNotNull('value')
+            ->with('prospect')
+            ->get();
+
+        foreach ($prospectBrokerContacts as $contact) {
+            if ($contact->prospect && filter_var($contact->value, FILTER_VALIDATE_EMAIL)) {
+                $email = strtolower($contact->value);
+                $emails[$email] = [
+                    'type' => 'prospect',
+                    'id' => $contact->prospect_id,
+                ];
+            }
+        }
+
+        // Get customer broker contacts
+        $customerBrokerContacts = FulfilBrokerContact::all();
+        foreach ($customerBrokerContacts as $contact) {
+            $email = strtolower($contact->email);
+            // Don't overwrite prospect broker emails (prospect takes priority)
+            if (!isset($emails[$email])) {
+                $emails[$email] = [
+                    'type' => 'customer',
+                    'id' => $contact->fulfil_party_id,
+                ];
+            }
+        }
+
+        return $emails;
     }
 
     /**

--- a/database/migrations/2026_03_12_133323_add_uncategorized_type_to_prospect_contacts_table.php
+++ b/database/migrations/2026_03_12_133323_add_uncategorized_type_to_prospect_contacts_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Note: The 'type' column is a varchar, so no schema change is needed.
+     * This migration documents the addition of 'uncategorized' as a valid type value.
+     * Valid types: buyer, accounts_payable, logistics, uncategorized
+     */
+    public function up(): void
+    {
+        // No schema change needed - type column is varchar
+        // New type 'uncategorized' is now supported for contact discovery
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // No schema change to revert
+    }
+};

--- a/database/migrations/2026_03_12_133413_create_fulfil_uncategorized_contacts_table.php
+++ b/database/migrations/2026_03_12_133413_create_fulfil_uncategorized_contacts_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('fulfil_uncategorized_contacts', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('fulfil_party_id');
+            $table->string('name')->default('');
+            $table->string('email');
+            $table->datetime('last_emailed_at')->nullable();
+            $table->datetime('last_received_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('fulfil_party_id')
+                ->references('fulfil_party_id')
+                ->on('fulfil_customer_metadata')
+                ->onDelete('cascade');
+
+            $table->unique(['fulfil_party_id', 'email']);
+            $table->index('fulfil_party_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('fulfil_uncategorized_contacts');
+    }
+};

--- a/database/migrations/2026_03_12_133657_add_type_to_fulfil_uncategorized_contacts_table.php
+++ b/database/migrations/2026_03_12_133657_add_type_to_fulfil_uncategorized_contacts_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('fulfil_uncategorized_contacts', function (Blueprint $table) {
+            // Type: null = uncategorized, or 'buyer', 'accounts_payable', 'logistics'
+            $table->string('type')->nullable()->after('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('fulfil_uncategorized_contacts', function (Blueprint $table) {
+            $table->dropColumn('type');
+        });
+    }
+};

--- a/database/migrations/2026_03_12_142306_add_broker_fields_to_prospects_table.php
+++ b/database/migrations/2026_03_12_142306_add_broker_fields_to_prospects_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('prospects', function (Blueprint $table) {
+            $table->boolean('broker')->default(false)->after('company_urls');
+            $table->decimal('broker_commission', 5, 2)->nullable()->after('broker');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('prospects', function (Blueprint $table) {
+            $table->dropColumn(['broker', 'broker_commission']);
+        });
+    }
+};

--- a/database/migrations/2026_03_12_142314_add_broker_fields_to_fulfil_customer_metadata_table.php
+++ b/database/migrations/2026_03_12_142314_add_broker_fields_to_fulfil_customer_metadata_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('fulfil_customer_metadata', function (Blueprint $table) {
+            $table->boolean('broker')->default(false)->after('company_urls');
+            $table->decimal('broker_commission', 5, 2)->nullable()->after('broker');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('fulfil_customer_metadata', function (Blueprint $table) {
+            $table->dropColumn(['broker', 'broker_commission']);
+        });
+    }
+};

--- a/database/migrations/2026_03_12_142333_create_fulfil_broker_contacts_table.php
+++ b/database/migrations/2026_03_12_142333_create_fulfil_broker_contacts_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('fulfil_broker_contacts', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('fulfil_party_id');
+            $table->string('name');
+            $table->string('email');
+            $table->datetime('last_emailed_at')->nullable();
+            $table->datetime('last_received_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('fulfil_party_id')
+                ->references('fulfil_party_id')
+                ->on('fulfil_customer_metadata')
+                ->onDelete('cascade');
+
+            $table->unique(['fulfil_party_id', 'email']);
+            $table->index('fulfil_party_id');
+            $table->index('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('fulfil_broker_contacts');
+    }
+};

--- a/database/migrations/2026_03_12_143850_add_broker_company_name_to_prospects_table.php
+++ b/database/migrations/2026_03_12_143850_add_broker_company_name_to_prospects_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('prospects', function (Blueprint $table) {
+            $table->string('broker_company_name')->nullable()->after('broker_commission');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('prospects', function (Blueprint $table) {
+            $table->dropColumn('broker_company_name');
+        });
+    }
+};

--- a/database/migrations/2026_03_12_143851_add_broker_company_name_to_fulfil_customer_metadata_table.php
+++ b/database/migrations/2026_03_12_143851_add_broker_company_name_to_fulfil_customer_metadata_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('fulfil_customer_metadata', function (Blueprint $table) {
+            $table->string('broker_company_name')->nullable()->after('broker_commission');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('fulfil_customer_metadata', function (Blueprint $table) {
+            $table->dropColumn('broker_company_name');
+        });
+    }
+};

--- a/resources/js/Pages/ActiveCustomers/Show.tsx
+++ b/resources/js/Pages/ActiveCustomers/Show.tsx
@@ -14,6 +14,31 @@ interface BuyerContact {
     last_received_at: string | null;
 }
 
+interface LocalContact {
+    id: number;
+    name: string;
+    email: string;
+    is_local?: boolean;
+    last_emailed_at?: string | null;
+    last_received_at?: string | null;
+}
+
+interface UncategorizedContact {
+    id: number;
+    name: string;
+    email: string;
+    last_emailed_at: string | null;
+    last_received_at: string | null;
+}
+
+interface BrokerContact {
+    id: number;
+    name: string;
+    email: string;
+    last_emailed_at: string | null;
+    last_received_at: string | null;
+}
+
 interface APContact {
     name: string;
     value: string;
@@ -34,6 +59,9 @@ interface Customer {
     receivable: number | null;
     receivable_today: number | null;
     company_urls: string[];
+    broker: boolean;
+    broker_commission: number | null;
+    broker_company_name: string | null;
 }
 
 interface PriceList {
@@ -88,6 +116,11 @@ interface OutstandingInvoice {
 interface Props {
     customer: Customer;
     buyerContacts: BuyerContact[];
+    localBuyers: LocalContact[];
+    localAP: LocalContact[];
+    localLogistics: LocalContact[];
+    uncategorizedContacts: UncategorizedContact[];
+    brokerContacts: BrokerContact[];
     monthlyRevenue: MonthlyRevenue[];
     topProducts: TopProduct[];
     upcomingOrders: UpcomingOrder[];
@@ -105,6 +138,14 @@ interface CustomerDetailsForm {
     shipping_terms_category_id: string;
     shelf_life_requirement: string;
     vendor_guide: string;
+    broker: boolean;
+    broker_commission: string;
+    broker_company_name: string;
+}
+
+interface BrokerContactForm {
+    name: string;
+    email: string;
 }
 
 interface ContactsForm {
@@ -204,6 +245,11 @@ function PlusIcon({ className = "h-4 w-4" }: { className?: string }) {
 export default function Show({
     customer,
     buyerContacts,
+    localBuyers,
+    localAP,
+    localLogistics,
+    uncategorizedContacts,
+    brokerContacts,
     monthlyRevenue,
     topProducts,
     upcomingOrders,
@@ -219,6 +265,9 @@ export default function Show({
     const [editingCompanyUrls, setEditingCompanyUrls] = useState(false);
     const [saving, setSaving] = useState(false);
 
+    // Track contacts being categorized (contact id -> selected type)
+    const [categorizingContacts, setCategorizingContacts] = useState<Record<number, string>>({});
+
     // Company URLs form state
     const [companyUrlsForm, setCompanyUrlsForm] = useState<string[]>(
         customer.company_urls?.length > 0 ? [...customer.company_urls] : ['']
@@ -232,7 +281,16 @@ export default function Show({
         shipping_terms_category_id: shippingTerms.find(st => st.name === customer.shipping_terms)?.id.toString() || '',
         shelf_life_requirement: customer.shelf_life_requirement || '',
         vendor_guide: customer.vendor_guide || '',
+        broker: customer.broker || false,
+        broker_commission: customer.broker_commission?.toString() || '',
+        broker_company_name: customer.broker_company_name || '',
     });
+
+    // Broker section states
+    const [editingBroker, setEditingBroker] = useState(false);
+    const [brokerContactsForm, setBrokerContactsForm] = useState<BrokerContactForm[]>(
+        brokerContacts?.map(c => ({ name: c.name, email: c.email })) || []
+    );
 
     const [contactsForm, setContactsForm] = useState<ContactsForm>({
         buyers: customer.buyers?.length > 0 ? [...customer.buyers] : [{ name: '', email: '' }],
@@ -347,6 +405,9 @@ export default function Show({
             shipping_terms_category_id: shippingTerms.find(st => st.name === customer.shipping_terms)?.id.toString() || '',
             shelf_life_requirement: customer.shelf_life_requirement || '',
             vendor_guide: customer.vendor_guide || '',
+            broker: customer.broker || false,
+            broker_commission: customer.broker_commission?.toString() || '',
+            broker_company_name: customer.broker_company_name || '',
         });
         setEditingDetails(false);
         setDetailsErrors({});
@@ -380,6 +441,8 @@ export default function Show({
                     shipping_terms_category_id: parseInt(detailsForm.shipping_terms_category_id),
                     shelf_life_requirement: parseInt(detailsForm.shelf_life_requirement),
                     vendor_guide: detailsForm.vendor_guide || null,
+                    broker: detailsForm.broker,
+                    broker_commission: detailsForm.broker_commission ? parseFloat(detailsForm.broker_commission) : null,
                 }),
             });
 
@@ -493,6 +556,105 @@ export default function Show({
             ...prev,
             logistics: prev.logistics.map((l, i) => i === index ? { ...l, [field]: value } : l),
         }));
+    };
+
+    // Categorize an uncategorized local contact
+    const categorizeContact = async (contactId: number, newType: string) => {
+        if (!contactId || !newType) return;
+
+        try {
+            const response = await fetch(route('customers.contacts.categorize', { customerId: customer.id, contactId }), {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
+                },
+                body: JSON.stringify({ type: newType }),
+            });
+
+            if (response.ok) {
+                setCategorizingContacts({});
+                router.reload();
+            } else {
+                const data = await response.json();
+                alert(data.message || 'Failed to categorize contact');
+            }
+        } catch (error) {
+            alert('Failed to categorize contact');
+        }
+    };
+
+    // Delete a local contact
+    const deleteLocalContact = async (contactId: number) => {
+        if (!confirm('Are you sure you want to delete this contact?')) return;
+
+        try {
+            const response = await fetch(route('customers.contacts.delete', { customerId: customer.id, contactId }), {
+                method: 'DELETE',
+                headers: {
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
+                },
+            });
+
+            if (response.ok) {
+                router.reload();
+            } else {
+                const data = await response.json();
+                alert(data.message || 'Failed to delete contact');
+            }
+        } catch (error) {
+            alert('Failed to delete contact');
+        }
+    };
+
+    // Broker contact management
+    const cancelBrokerEdit = () => {
+        setBrokerContactsForm(brokerContacts?.map(c => ({ name: c.name, email: c.email })) || []);
+        setEditingBroker(false);
+    };
+
+    const addBrokerContactForm = () => {
+        setBrokerContactsForm(prev => [...prev, { name: '', email: '' }]);
+    };
+
+    const removeBrokerContactForm = (index: number) => {
+        setBrokerContactsForm(prev => prev.filter((_, i) => i !== index));
+    };
+
+    const updateBrokerContactForm = (index: number, field: 'name' | 'email', value: string) => {
+        setBrokerContactsForm(prev => prev.map((c, i) => i === index ? { ...c, [field]: value } : c));
+    };
+
+    const saveBroker = async () => {
+        setSaving(true);
+        try {
+            // First update broker flag and commission
+            const brokerResponse = await fetch(route('customers.broker.update', customer.id), {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
+                },
+                body: JSON.stringify({
+                    broker: detailsForm.broker,
+                    broker_commission: detailsForm.broker_commission ? parseFloat(detailsForm.broker_commission) : null,
+                    broker_company_name: detailsForm.broker_company_name || null,
+                    broker_contacts: brokerContactsForm.filter(c => c.name.trim()),
+                }),
+            });
+
+            if (brokerResponse.ok) {
+                setEditingBroker(false);
+                router.reload();
+            } else {
+                const data = await brokerResponse.json();
+                alert(data.message || 'Failed to save broker settings');
+            }
+        } catch (error) {
+            alert('Failed to save broker settings');
+        } finally {
+            setSaving(false);
+        }
     };
 
     // Company URL management
@@ -665,6 +827,16 @@ export default function Show({
                                             ) : '-'}
                                         </dd>
                                     </div>
+                                    <div>
+                                        <dt className="text-sm font-medium text-gray-500">Broker</dt>
+                                        <dd className="text-sm text-gray-900">
+                                            {customer.broker ? (
+                                                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs bg-purple-100 text-purple-800">
+                                                    Yes
+                                                </span>
+                                            ) : 'No'}
+                                        </dd>
+                                    </div>
                                 </dl>
                             ) : (
                                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -748,10 +920,174 @@ export default function Show({
                                         />
                                         {detailsErrors.vendor_guide && <p className="mt-1 text-xs text-red-600">{detailsErrors.vendor_guide}</p>}
                                     </div>
+
+                                    <div className="flex items-center gap-4">
+                                        <label className="flex items-center gap-2 cursor-pointer">
+                                            <input
+                                                type="checkbox"
+                                                checked={detailsForm.broker}
+                                                onChange={(e) => setDetailsForm(prev => ({ ...prev, broker: e.target.checked }))}
+                                                className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                            />
+                                            <span className="text-sm font-medium text-gray-700">Uses Broker</span>
+                                        </label>
+                                    </div>
                                 </div>
                             )}
                         </div>
                     </div>
+
+                    {/* Broker Section - Only visible when broker=true */}
+                    {(customer.broker || detailsForm.broker) && (
+                        <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg border-l-4 border-purple-400">
+                            <div className="p-6">
+                                <div className="mb-4 flex items-center justify-between">
+                                    <h3 className="text-lg font-medium text-gray-900 flex items-center gap-2">
+                                        Broker
+                                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs bg-purple-100 text-purple-800">
+                                            Commission: {customer.broker_commission ?? detailsForm.broker_commission ?? 0}%
+                                        </span>
+                                    </h3>
+                                    {!editingBroker ? (
+                                        <button
+                                            onClick={() => setEditingBroker(true)}
+                                            className="text-gray-400 hover:text-gray-600"
+                                            title="Edit"
+                                        >
+                                            <PencilIcon />
+                                        </button>
+                                    ) : (
+                                        <div className="flex gap-2">
+                                            <button
+                                                onClick={cancelBrokerEdit}
+                                                className="rounded border border-gray-300 bg-white px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
+                                            >
+                                                Cancel
+                                            </button>
+                                            <button
+                                                onClick={saveBroker}
+                                                disabled={saving}
+                                                className="rounded bg-indigo-600 px-3 py-1 text-sm text-white hover:bg-indigo-700 disabled:opacity-50"
+                                            >
+                                                {saving ? 'Saving...' : 'Save'}
+                                            </button>
+                                        </div>
+                                    )}
+                                </div>
+
+                                {!editingBroker ? (
+                                    <div>
+                                        <div className="grid grid-cols-2 gap-4 mb-4">
+                                            <div>
+                                                <h4 className="text-sm font-medium text-gray-700 mb-2">Broker Company</h4>
+                                                <p className="text-sm text-gray-900">{customer.broker_company_name || '-'}</p>
+                                            </div>
+                                            <div>
+                                                <h4 className="text-sm font-medium text-gray-700 mb-2">Commission</h4>
+                                                <p className="text-sm text-gray-900">{customer.broker_commission ?? 0}%</p>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <h4 className="text-sm font-medium text-gray-700 mb-2">Broker Contacts</h4>
+                                            {brokerContacts && brokerContacts.length > 0 ? (
+                                                <ul className="space-y-2">
+                                                    {brokerContacts.map((contact) => (
+                                                        <li key={contact.id} className="text-sm">
+                                                            <div className="text-gray-900">{contact.name}</div>
+                                                            {contact.email && (
+                                                                <div className="text-gray-500">{contact.email}</div>
+                                                            )}
+                                                            <div className="mt-1 flex gap-3 text-xs text-gray-400">
+                                                                <span>Sent: {formatRelativeDate(contact.last_emailed_at)}</span>
+                                                                <span>Received: {formatRelativeDate(contact.last_received_at)}</span>
+                                                            </div>
+                                                        </li>
+                                                    ))}
+                                                </ul>
+                                            ) : (
+                                                <p className="text-sm text-gray-400">No broker contacts</p>
+                                            )}
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <div className="space-y-4">
+                                        <div className="grid grid-cols-2 gap-4">
+                                            <div>
+                                                <label className="block text-sm font-medium text-gray-700">Broker Company Name</label>
+                                                <input
+                                                    type="text"
+                                                    value={detailsForm.broker_company_name}
+                                                    onChange={(e) => setDetailsForm(prev => ({ ...prev, broker_company_name: e.target.value }))}
+                                                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                                    placeholder="e.g., HRG Brokers"
+                                                />
+                                            </div>
+                                            <div>
+                                                <label className="block text-sm font-medium text-gray-700">Commission (%)</label>
+                                                <input
+                                                    type="number"
+                                                    min="0"
+                                                    max="100"
+                                                    step="0.1"
+                                                    value={detailsForm.broker_commission}
+                                                    onChange={(e) => setDetailsForm(prev => ({ ...prev, broker_commission: e.target.value }))}
+                                                    className="mt-1 block w-32 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                                    placeholder="0.0"
+                                                />
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div className="mb-2 flex items-center justify-between">
+                                                <h4 className="text-sm font-medium text-gray-700">Broker Contacts</h4>
+                                                <button
+                                                    type="button"
+                                                    onClick={addBrokerContactForm}
+                                                    className="flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-800"
+                                                >
+                                                    <PlusIcon className="h-3 w-3" /> Add
+                                                </button>
+                                            </div>
+                                            {brokerContactsForm.length === 0 ? (
+                                                <p className="text-sm text-gray-400">No broker contacts</p>
+                                            ) : (
+                                                <div className="space-y-2">
+                                                    {brokerContactsForm.map((contact, idx) => (
+                                                        <div key={idx} className="flex gap-2">
+                                                            <div className="flex-1">
+                                                                <input
+                                                                    type="text"
+                                                                    value={contact.name}
+                                                                    onChange={(e) => updateBrokerContactForm(idx, 'name', e.target.value)}
+                                                                    placeholder="Name"
+                                                                    className="block w-full rounded-md text-sm shadow-sm focus:ring-indigo-500 border-gray-300"
+                                                                />
+                                                            </div>
+                                                            <div className="flex-1">
+                                                                <input
+                                                                    type="email"
+                                                                    value={contact.email}
+                                                                    onChange={(e) => updateBrokerContactForm(idx, 'email', e.target.value)}
+                                                                    placeholder="Email"
+                                                                    className="block w-full rounded-md text-sm shadow-sm focus:ring-indigo-500 border-gray-300"
+                                                                />
+                                                            </div>
+                                                            <button
+                                                                type="button"
+                                                                onClick={() => removeBrokerContactForm(idx)}
+                                                                className="text-red-400 hover:text-red-600"
+                                                            >
+                                                                <XIcon />
+                                                            </button>
+                                                        </div>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    )}
 
                     {/* Contacts */}
                     <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
@@ -787,14 +1123,15 @@ export default function Show({
                             </div>
 
                             {!editingContacts ? (
+                                <>
                                 <div className="grid gap-6 sm:grid-cols-3">
                                     {/* Buyers */}
                                     <div>
                                         <h4 className="mb-2 text-sm font-medium text-gray-700">Buyers</h4>
-                                        {buyerContacts && buyerContacts.length > 0 ? (
+                                        {(buyerContacts && buyerContacts.length > 0) || (localBuyers && localBuyers.length > 0) ? (
                                             <ul className="space-y-3">
-                                                {buyerContacts.map((contact, idx) => (
-                                                    <li key={idx} className="text-sm">
+                                                {buyerContacts?.map((contact, idx) => (
+                                                    <li key={`fulfil-${idx}`} className="text-sm">
                                                         <div className="text-gray-900">{contact.name}</div>
                                                         {contact.email && (
                                                             <div className="text-gray-500">{contact.email}</div>
@@ -809,6 +1146,21 @@ export default function Show({
                                                         </div>
                                                     </li>
                                                 ))}
+                                                {localBuyers?.map((contact) => (
+                                                    <li key={`local-${contact.id}`} className="text-sm bg-blue-50 rounded p-2 -mx-2">
+                                                        <div className="flex justify-between items-start">
+                                                            <div>
+                                                                <div className="text-gray-900">{contact.name || <span className="text-gray-400 italic">No name</span>}</div>
+                                                                <div className="text-gray-500">{contact.email}</div>
+                                                                <div className="mt-1 flex gap-3 text-xs text-gray-400">
+                                                                    <span>Sent: {formatRelativeDate(contact.last_emailed_at ?? null)}</span>
+                                                                    <span>Received: {formatRelativeDate(contact.last_received_at ?? null)}</span>
+                                                                </div>
+                                                            </div>
+                                                            <span className="text-xs text-blue-600 bg-blue-100 px-1.5 py-0.5 rounded">Local</span>
+                                                        </div>
+                                                    </li>
+                                                ))}
                                             </ul>
                                         ) : (
                                             <p className="text-sm text-gray-400">-</p>
@@ -818,10 +1170,10 @@ export default function Show({
                                     {/* Accounts Payable */}
                                     <div>
                                         <h4 className="mb-2 text-sm font-medium text-gray-700">Accounts Payable</h4>
-                                        {customer.accounts_payable && customer.accounts_payable.length > 0 ? (
+                                        {(customer.accounts_payable && customer.accounts_payable.length > 0) || (localAP && localAP.length > 0) ? (
                                             <ul className="space-y-2">
-                                                {customer.accounts_payable.map((contact, idx) => (
-                                                    <li key={idx} className="text-sm">
+                                                {customer.accounts_payable?.map((contact, idx) => (
+                                                    <li key={`fulfil-${idx}`} className="text-sm">
                                                         <div className="text-gray-900">{contact.name}</div>
                                                         {contact.value && (
                                                             <div className="text-gray-500 break-all">
@@ -834,6 +1186,17 @@ export default function Show({
                                                         )}
                                                     </li>
                                                 ))}
+                                                {localAP?.map((contact) => (
+                                                    <li key={`local-${contact.id}`} className="text-sm bg-blue-50 rounded p-2 -mx-2">
+                                                        <div className="flex justify-between items-start">
+                                                            <div>
+                                                                <div className="text-gray-900">{contact.name || <span className="text-gray-400 italic">No name</span>}</div>
+                                                                <div className="text-gray-500">{contact.email}</div>
+                                                            </div>
+                                                            <span className="text-xs text-blue-600 bg-blue-100 px-1.5 py-0.5 rounded">Local</span>
+                                                        </div>
+                                                    </li>
+                                                ))}
                                             </ul>
                                         ) : (
                                             <p className="text-sm text-gray-400">-</p>
@@ -843,14 +1206,25 @@ export default function Show({
                                     {/* Logistics */}
                                     <div>
                                         <h4 className="mb-2 text-sm font-medium text-gray-700">Logistics</h4>
-                                        {customer.logistics && customer.logistics.length > 0 ? (
+                                        {(customer.logistics && customer.logistics.length > 0) || (localLogistics && localLogistics.length > 0) ? (
                                             <ul className="space-y-2">
-                                                {customer.logistics.map((contact, idx) => (
-                                                    <li key={idx} className="text-sm">
+                                                {customer.logistics?.map((contact, idx) => (
+                                                    <li key={`fulfil-${idx}`} className="text-sm">
                                                         <div className="text-gray-900">{contact.name}</div>
                                                         {contact.email && (
                                                             <div className="text-gray-500">{contact.email}</div>
                                                         )}
+                                                    </li>
+                                                ))}
+                                                {localLogistics?.map((contact) => (
+                                                    <li key={`local-${contact.id}`} className="text-sm bg-blue-50 rounded p-2 -mx-2">
+                                                        <div className="flex justify-between items-start">
+                                                            <div>
+                                                                <div className="text-gray-900">{contact.name || <span className="text-gray-400 italic">No name</span>}</div>
+                                                                <div className="text-gray-500">{contact.email}</div>
+                                                            </div>
+                                                            <span className="text-xs text-blue-600 bg-blue-100 px-1.5 py-0.5 rounded">Local</span>
+                                                        </div>
                                                     </li>
                                                 ))}
                                             </ul>
@@ -859,6 +1233,63 @@ export default function Show({
                                         )}
                                     </div>
                                 </div>
+
+                                {/* Uncategorized Contacts Section */}
+                                {uncategorizedContacts && uncategorizedContacts.length > 0 && (
+                                    <div className="mt-6 pt-6 border-t border-gray-200">
+                                        <h4 className="mb-3 text-sm font-medium text-gray-700 flex items-center gap-2">
+                                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs bg-yellow-100 text-yellow-800">
+                                                Uncategorized
+                                            </span>
+                                            <span className="text-gray-500 font-normal">
+                                                ({uncategorizedContacts.length} discovered from emails)
+                                            </span>
+                                        </h4>
+                                        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                                            {uncategorizedContacts.map((contact) => (
+                                                <div key={contact.id} className="p-3 bg-yellow-50 rounded-lg border border-yellow-100">
+                                                    <div className="flex justify-between items-start">
+                                                        <div className="flex-1 min-w-0">
+                                                            <div className="text-sm text-gray-900 font-medium truncate">
+                                                                {contact.name || <span className="text-gray-400 italic">No name</span>}
+                                                            </div>
+                                                            <div className="text-sm text-gray-500 truncate">{contact.email}</div>
+                                                            <div className="mt-1 flex gap-3 text-xs text-gray-400">
+                                                                <span>Sent: {formatRelativeDate(contact.last_emailed_at)}</span>
+                                                                <span>Received: {formatRelativeDate(contact.last_received_at)}</span>
+                                                            </div>
+                                                        </div>
+                                                        <div className="ml-2 flex flex-col gap-1">
+                                                            <select
+                                                                value={categorizingContacts[contact.id] || ''}
+                                                                onChange={(e) => {
+                                                                    const type = e.target.value;
+                                                                    if (type) {
+                                                                        setCategorizingContacts(prev => ({ ...prev, [contact.id]: type }));
+                                                                        categorizeContact(contact.id, type);
+                                                                    }
+                                                                }}
+                                                                className="text-xs rounded border-gray-300 py-1 pl-2 pr-6 focus:border-indigo-500 focus:ring-indigo-500"
+                                                            >
+                                                                <option value="">Categorize...</option>
+                                                                <option value="buyer">Buyer</option>
+                                                                <option value="accounts_payable">Accounts Payable</option>
+                                                                <option value="logistics">Logistics</option>
+                                                            </select>
+                                                            <button
+                                                                onClick={() => deleteLocalContact(contact.id)}
+                                                                className="text-xs text-red-500 hover:text-red-700"
+                                                            >
+                                                                Delete
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                                </>
                             ) : (
                                 <div className="space-y-6">
                                     {/* Buyers Edit */}

--- a/resources/js/Pages/Prospects/Show.tsx
+++ b/resources/js/Pages/Prospects/Show.tsx
@@ -38,6 +38,22 @@ interface ShippingTerm {
     name: string;
 }
 
+interface UncategorizedContact {
+    id: number;
+    name: string;
+    value: string;
+    last_emailed_at?: string | null;
+    last_received_at?: string | null;
+}
+
+interface BrokerContact {
+    id?: number;
+    name: string;
+    value: string;
+    last_emailed_at?: string | null;
+    last_received_at?: string | null;
+}
+
 interface Prospect {
     id: number;
     company_name: string;
@@ -49,9 +65,14 @@ interface Prospect {
     shelf_life_requirement: number | null;
     vendor_guide: string | null;
     company_urls: string[];
+    broker: boolean;
+    broker_commission: number | null;
+    broker_company_name: string | null;
+    broker_contacts: BrokerContact[];
     buyers: Contact[];
     accounts_payable: Contact[];
     logistics: Contact[];
+    uncategorized: UncategorizedContact[];
     products: Product[];
     product_ids: number[];
 }
@@ -74,12 +95,20 @@ interface DetailsForm {
     shelf_life_requirement: string;
     vendor_guide: string;
     company_urls: string[];
+    broker: boolean;
+    broker_commission: string;
+    broker_company_name: string;
+}
+
+interface BrokerContactsForm {
+    broker_contacts: BrokerContact[];
 }
 
 interface ContactsForm {
     buyers: Contact[];
     accounts_payable: Contact[];
     logistics: Contact[];
+    uncategorized: Contact[];
 }
 
 interface ProductsForm {
@@ -155,15 +184,29 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
         shelf_life_requirement: prospect.shelf_life_requirement?.toString() || '',
         vendor_guide: prospect.vendor_guide || '',
         company_urls: prospect.company_urls || [],
+        broker: prospect.broker || false,
+        broker_commission: prospect.broker_commission?.toString() || '',
+        broker_company_name: prospect.broker_company_name || '',
     });
 
     const [newCompanyUrl, setNewCompanyUrl] = useState('');
+
+    // Broker contacts state
+    const [editingBroker, setEditingBroker] = useState(false);
+    const [brokerContactsForm, setBrokerContactsForm] = useState<BrokerContactsForm>({
+        broker_contacts: prospect.broker_contacts?.length > 0 ? [...prospect.broker_contacts] : [],
+    });
+    const [brokerContactsErrors, setBrokerContactsErrors] = useState<ValidationErrors>({});
 
     const [contactsForm, setContactsForm] = useState<ContactsForm>({
         buyers: prospect.buyers?.length > 0 ? [...prospect.buyers] : [],
         accounts_payable: prospect.accounts_payable?.length > 0 ? [...prospect.accounts_payable] : [],
         logistics: prospect.logistics?.length > 0 ? [...prospect.logistics] : [],
+        uncategorized: prospect.uncategorized?.length > 0 ? [...prospect.uncategorized] : [],
     });
+
+    // Track contacts being categorized (contact id -> selected type)
+    const [categorizingContacts, setCategorizingContacts] = useState<Record<number, string>>({});
 
     const [productsForm, setProductsForm] = useState<ProductsForm>({
         product_ids: [...prospect.product_ids],
@@ -230,6 +273,16 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
             }
         });
 
+        // Validate uncategorized
+        contactsForm.uncategorized.forEach((contact, idx) => {
+            if (!contact.name || contact.name.length < 1) {
+                errors[`uncategorized.${idx}.name`] = 'Name is required';
+            }
+            if (contact.value && !isValidEmail(contact.value)) {
+                errors[`uncategorized.${idx}.value`] = 'Invalid email address';
+            }
+        });
+
         setContactsErrors(errors);
     }, [contactsForm, editingContacts]);
 
@@ -243,6 +296,9 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
             shelf_life_requirement: prospect.shelf_life_requirement?.toString() || '',
             vendor_guide: prospect.vendor_guide || '',
             company_urls: prospect.company_urls || [],
+            broker: prospect.broker || false,
+            broker_commission: prospect.broker_commission?.toString() || '',
+            broker_company_name: prospect.broker_company_name || '',
         });
         setNewCompanyUrl('');
         setEditingDetails(false);
@@ -254,9 +310,11 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
             buyers: prospect.buyers?.length > 0 ? [...prospect.buyers] : [],
             accounts_payable: prospect.accounts_payable?.length > 0 ? [...prospect.accounts_payable] : [],
             logistics: prospect.logistics?.length > 0 ? [...prospect.logistics] : [],
+            uncategorized: prospect.uncategorized?.length > 0 ? [...prospect.uncategorized] : [],
         });
         setEditingContacts(false);
         setContactsErrors({});
+        setCategorizingContacts({});
     };
 
     const cancelProductsEdit = () => {
@@ -329,11 +387,13 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
                     buyers: cleanContacts(contactsForm.buyers),
                     accounts_payable: cleanContacts(contactsForm.accounts_payable),
                     logistics: cleanContacts(contactsForm.logistics),
+                    uncategorized: cleanContacts(contactsForm.uncategorized),
                 }),
             });
 
             if (response.ok) {
                 setEditingContacts(false);
+                setCategorizingContacts({});
                 router.reload({ only: ['prospect'] });
             } else {
                 const data = await response.json();
@@ -441,6 +501,138 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
             logistics: prev.logistics.map((l, i) => i === index ? { ...l, [field]: value } : l),
         }));
     };
+
+    // Contact management - Uncategorized
+    const addUncategorized = () => {
+        setContactsForm(prev => ({
+            ...prev,
+            uncategorized: [...prev.uncategorized, { name: '', value: '' }],
+        }));
+    };
+
+    const removeUncategorized = (index: number) => {
+        setContactsForm(prev => ({
+            ...prev,
+            uncategorized: prev.uncategorized.filter((_, i) => i !== index),
+        }));
+    };
+
+    const updateUncategorized = (index: number, field: 'name' | 'value', value: string) => {
+        setContactsForm(prev => ({
+            ...prev,
+            uncategorized: prev.uncategorized.map((c, i) => i === index ? { ...c, [field]: value } : c),
+        }));
+    };
+
+    // Categorize a contact (move from uncategorized to a specific type)
+    const categorizeContact = async (contactId: number, newType: string) => {
+        if (!contactId || !newType) return;
+
+        try {
+            const response = await fetch(route('prospects.contacts.categorize', { prospectId: prospect.id, contactId }), {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
+                },
+                body: JSON.stringify({ type: newType }),
+            });
+
+            if (response.ok) {
+                setCategorizingContacts({});
+                router.reload({ only: ['prospect'] });
+            } else {
+                const data = await response.json();
+                alert(data.message || 'Failed to categorize contact');
+            }
+        } catch (error) {
+            alert('Failed to categorize contact');
+        }
+    };
+
+    // Broker contact management
+    const addBrokerContact = () => {
+        setBrokerContactsForm(prev => ({
+            ...prev,
+            broker_contacts: [...prev.broker_contacts, { name: '', value: '' }],
+        }));
+    };
+
+    const removeBrokerContact = (index: number) => {
+        setBrokerContactsForm(prev => ({
+            ...prev,
+            broker_contacts: prev.broker_contacts.filter((_, i) => i !== index),
+        }));
+    };
+
+    const updateBrokerContact = (index: number, field: 'name' | 'value', value: string) => {
+        setBrokerContactsForm(prev => ({
+            ...prev,
+            broker_contacts: prev.broker_contacts.map((c, i) => i === index ? { ...c, [field]: value } : c),
+        }));
+    };
+
+    const cancelBrokerEdit = () => {
+        setBrokerContactsForm({
+            broker_contacts: prospect.broker_contacts?.length > 0 ? [...prospect.broker_contacts] : [],
+        });
+        setEditingBroker(false);
+        setBrokerContactsErrors({});
+    };
+
+    const saveBroker = async () => {
+        if (Object.keys(brokerContactsErrors).length > 0) return;
+
+        setSaving(true);
+        try {
+            const cleanContacts = (contacts: BrokerContact[]) =>
+                contacts.filter(c => c.name).map(c => ({ name: c.name, value: c.value || '' }));
+
+            const response = await fetch(route('prospects.update', prospect.id), {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
+                },
+                body: JSON.stringify({
+                    broker: detailsForm.broker,
+                    broker_commission: detailsForm.broker_commission ? parseFloat(detailsForm.broker_commission) : null,
+                    broker_company_name: detailsForm.broker_company_name || null,
+                    broker_contacts: cleanContacts(brokerContactsForm.broker_contacts),
+                }),
+            });
+
+            if (response.ok) {
+                setEditingBroker(false);
+                router.reload({ only: ['prospect'] });
+            } else {
+                const data = await response.json();
+                alert(data.message || 'Failed to save broker settings');
+            }
+        } catch (error) {
+            alert('Failed to save broker settings');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    // Validate broker contacts
+    useEffect(() => {
+        if (!editingBroker) return;
+
+        const errors: ValidationErrors = {};
+        brokerContactsForm.broker_contacts.forEach((contact, idx) => {
+            if (!contact.name || contact.name.length < 1) {
+                errors[`broker_contacts.${idx}.name`] = 'Name is required';
+            }
+            if (contact.value && !isValidEmail(contact.value)) {
+                errors[`broker_contacts.${idx}.value`] = 'Invalid email address';
+            }
+        });
+        setBrokerContactsErrors(errors);
+    }, [brokerContactsForm, editingBroker]);
+
+    const brokerContactsValid = Object.keys(brokerContactsErrors).length === 0;
 
     // Product management
     const addProduct = (productId: number) => {
@@ -587,6 +779,16 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
                                                     ))}
                                                 </div>
                                             ) : '-'}
+                                        </dd>
+                                    </div>
+                                    <div>
+                                        <dt className="text-sm font-medium text-gray-500">Broker</dt>
+                                        <dd className="text-sm text-gray-900">
+                                            {prospect.broker ? (
+                                                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs bg-purple-100 text-purple-800">
+                                                    Yes
+                                                </span>
+                                            ) : 'No'}
                                         </dd>
                                     </div>
                                 </dl>
@@ -761,10 +963,174 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
                                             </button>
                                         </div>
                                     </div>
+
+                                    <div className="flex items-center gap-4">
+                                        <label className="flex items-center gap-2 cursor-pointer">
+                                            <input
+                                                type="checkbox"
+                                                checked={detailsForm.broker}
+                                                onChange={(e) => setDetailsForm(prev => ({ ...prev, broker: e.target.checked }))}
+                                                className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                            />
+                                            <span className="text-sm font-medium text-gray-700">Uses Broker</span>
+                                        </label>
+                                    </div>
                                 </div>
                             )}
                         </div>
                     </div>
+
+                    {/* Broker Section - Only visible when broker=true */}
+                    {(prospect.broker || detailsForm.broker) && (
+                        <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg border-l-4 border-purple-400">
+                            <div className="p-6">
+                                <div className="mb-4 flex items-center justify-between">
+                                    <h3 className="text-lg font-medium text-gray-900 flex items-center gap-2">
+                                        Broker
+                                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs bg-purple-100 text-purple-800">
+                                            Commission: {prospect.broker_commission ?? detailsForm.broker_commission ?? 0}%
+                                        </span>
+                                    </h3>
+                                    {!editingBroker ? (
+                                        <button
+                                            onClick={() => setEditingBroker(true)}
+                                            className="text-gray-400 hover:text-gray-600"
+                                            title="Edit"
+                                        >
+                                            <PencilIcon />
+                                        </button>
+                                    ) : (
+                                        <div className="flex gap-2">
+                                            <button
+                                                onClick={cancelBrokerEdit}
+                                                className="rounded border border-gray-300 bg-white px-3 py-1 text-sm text-gray-700 hover:bg-gray-50"
+                                            >
+                                                Cancel
+                                            </button>
+                                            <button
+                                                onClick={saveBroker}
+                                                disabled={!brokerContactsValid || saving}
+                                                className="rounded bg-indigo-600 px-3 py-1 text-sm text-white hover:bg-indigo-700 disabled:opacity-50"
+                                            >
+                                                {saving ? 'Saving...' : 'Save'}
+                                            </button>
+                                        </div>
+                                    )}
+                                </div>
+
+                                {!editingBroker ? (
+                                    <div>
+                                        <div className="grid grid-cols-2 gap-4 mb-4">
+                                            <div>
+                                                <h4 className="text-sm font-medium text-gray-700 mb-2">Broker Company</h4>
+                                                <p className="text-sm text-gray-900">{prospect.broker_company_name || '-'}</p>
+                                            </div>
+                                            <div>
+                                                <h4 className="text-sm font-medium text-gray-700 mb-2">Commission</h4>
+                                                <p className="text-sm text-gray-900">{prospect.broker_commission ?? 0}%</p>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <h4 className="text-sm font-medium text-gray-700 mb-2">Broker Contacts</h4>
+                                            {prospect.broker_contacts && prospect.broker_contacts.length > 0 ? (
+                                                <ul className="space-y-2">
+                                                    {prospect.broker_contacts.map((contact, idx) => (
+                                                        <li key={idx} className="text-sm">
+                                                            <div className="text-gray-900">{contact.name}</div>
+                                                            {contact.value && (
+                                                                <div className="text-gray-500">{contact.value}</div>
+                                                            )}
+                                                            <div className="mt-1 flex gap-3 text-xs text-gray-400">
+                                                                <span>Sent: {formatDate(contact.last_emailed_at)}</span>
+                                                                <span>Received: {formatDate(contact.last_received_at)}</span>
+                                                            </div>
+                                                        </li>
+                                                    ))}
+                                                </ul>
+                                            ) : (
+                                                <p className="text-sm text-gray-400">No broker contacts</p>
+                                            )}
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <div className="space-y-4">
+                                        <div className="grid grid-cols-2 gap-4">
+                                            <div>
+                                                <label className="block text-sm font-medium text-gray-700">Broker Company Name</label>
+                                                <input
+                                                    type="text"
+                                                    value={detailsForm.broker_company_name}
+                                                    onChange={(e) => setDetailsForm(prev => ({ ...prev, broker_company_name: e.target.value }))}
+                                                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                                    placeholder="e.g., HRG Brokers"
+                                                />
+                                            </div>
+                                            <div>
+                                                <label className="block text-sm font-medium text-gray-700">Commission (%)</label>
+                                                <input
+                                                    type="number"
+                                                    min="0"
+                                                    max="100"
+                                                    step="0.1"
+                                                    value={detailsForm.broker_commission}
+                                                    onChange={(e) => setDetailsForm(prev => ({ ...prev, broker_commission: e.target.value }))}
+                                                    className="mt-1 block w-32 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                                    placeholder="0.0"
+                                                />
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div className="mb-2 flex items-center justify-between">
+                                                <h4 className="text-sm font-medium text-gray-700">Broker Contacts</h4>
+                                                <button
+                                                    type="button"
+                                                    onClick={addBrokerContact}
+                                                    className="flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-800"
+                                                >
+                                                    <PlusIcon className="h-3 w-3" /> Add
+                                                </button>
+                                            </div>
+                                            {brokerContactsForm.broker_contacts.length === 0 ? (
+                                                <p className="text-sm text-gray-400">No broker contacts</p>
+                                            ) : (
+                                                <div className="space-y-2">
+                                                    {brokerContactsForm.broker_contacts.map((contact, idx) => (
+                                                        <div key={idx} className="flex gap-2">
+                                                            <div className="flex-1">
+                                                                <input
+                                                                    type="text"
+                                                                    value={contact.name}
+                                                                    onChange={(e) => updateBrokerContact(idx, 'name', e.target.value)}
+                                                                    placeholder="Name"
+                                                                    className={`block w-full rounded-md text-sm shadow-sm focus:ring-indigo-500 ${brokerContactsErrors[`broker_contacts.${idx}.name`] ? 'border-red-300' : 'border-gray-300'}`}
+                                                                />
+                                                            </div>
+                                                            <div className="flex-1">
+                                                                <input
+                                                                    type="email"
+                                                                    value={contact.value}
+                                                                    onChange={(e) => updateBrokerContact(idx, 'value', e.target.value)}
+                                                                    placeholder="Email"
+                                                                    className={`block w-full rounded-md text-sm shadow-sm focus:ring-indigo-500 ${brokerContactsErrors[`broker_contacts.${idx}.value`] ? 'border-red-300' : 'border-gray-300'}`}
+                                                                />
+                                                            </div>
+                                                            <button
+                                                                type="button"
+                                                                onClick={() => removeBrokerContact(idx)}
+                                                                className="text-red-400 hover:text-red-600"
+                                                            >
+                                                                <XIcon />
+                                                            </button>
+                                                        </div>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    )}
 
                     {/* Contacts */}
                     <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg">
@@ -800,6 +1166,7 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
                             </div>
 
                             {!editingContacts ? (
+                                <>
                                 <div className="grid gap-6 sm:grid-cols-3">
                                     {/* Buyers */}
                                     <div>
@@ -872,6 +1239,57 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
                                         )}
                                     </div>
                                 </div>
+
+                                {/* Uncategorized Contacts Section */}
+                                {prospect.uncategorized && prospect.uncategorized.length > 0 && (
+                                    <div className="mt-6 pt-6 border-t border-gray-200">
+                                        <h4 className="mb-3 text-sm font-medium text-gray-700 flex items-center gap-2">
+                                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs bg-yellow-100 text-yellow-800">
+                                                Uncategorized
+                                            </span>
+                                            <span className="text-gray-500 font-normal">
+                                                ({prospect.uncategorized.length} discovered from emails)
+                                            </span>
+                                        </h4>
+                                        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                                            {prospect.uncategorized.map((contact) => (
+                                                <div key={contact.id} className="p-3 bg-yellow-50 rounded-lg border border-yellow-100">
+                                                    <div className="flex justify-between items-start">
+                                                        <div className="flex-1 min-w-0">
+                                                            <div className="text-sm text-gray-900 font-medium truncate">
+                                                                {contact.name || <span className="text-gray-400 italic">No name</span>}
+                                                            </div>
+                                                            <div className="text-sm text-gray-500 truncate">{contact.value}</div>
+                                                            <div className="mt-1 flex gap-3 text-xs text-gray-400">
+                                                                <span>Sent: {formatDate(contact.last_emailed_at)}</span>
+                                                                <span>Received: {formatDate(contact.last_received_at)}</span>
+                                                            </div>
+                                                        </div>
+                                                        <div className="ml-2">
+                                                            <select
+                                                                value={categorizingContacts[contact.id] || ''}
+                                                                onChange={(e) => {
+                                                                    const type = e.target.value;
+                                                                    if (type) {
+                                                                        setCategorizingContacts(prev => ({ ...prev, [contact.id]: type }));
+                                                                        categorizeContact(contact.id, type);
+                                                                    }
+                                                                }}
+                                                                className="text-xs rounded border-gray-300 py-1 pl-2 pr-6 focus:border-indigo-500 focus:ring-indigo-500"
+                                                            >
+                                                                <option value="">Categorize...</option>
+                                                                <option value="buyer">Buyer</option>
+                                                                <option value="accounts_payable">Accounts Payable</option>
+                                                                <option value="logistics">Logistics</option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                                </>
                             ) : (
                                 <div className="space-y-6">
                                     {/* Buyers Edit */}
@@ -1011,6 +1429,62 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
                                                         <button
                                                             type="button"
                                                             onClick={() => removeLogistics(idx)}
+                                                            className="text-red-400 hover:text-red-600"
+                                                        >
+                                                            <XIcon />
+                                                        </button>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        )}
+                                    </div>
+
+                                    {/* Uncategorized Edit */}
+                                    <div className="pt-4 border-t border-gray-200">
+                                        <div className="mb-2 flex items-center justify-between">
+                                            <h4 className="text-sm font-medium text-gray-700 flex items-center gap-2">
+                                                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs bg-yellow-100 text-yellow-800">
+                                                    Uncategorized
+                                                </span>
+                                            </h4>
+                                            <button
+                                                type="button"
+                                                onClick={addUncategorized}
+                                                className="flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-800"
+                                            >
+                                                <PlusIcon className="h-3 w-3" /> Add
+                                            </button>
+                                        </div>
+                                        <p className="text-xs text-gray-500 mb-2">
+                                            These contacts were discovered from emails. Edit their name or categorize them to move to the appropriate section.
+                                        </p>
+                                        {contactsForm.uncategorized.length === 0 ? (
+                                            <p className="text-sm text-gray-400">No uncategorized contacts</p>
+                                        ) : (
+                                            <div className="space-y-2">
+                                                {contactsForm.uncategorized.map((contact, idx) => (
+                                                    <div key={idx} className="flex gap-2 bg-yellow-50 p-2 rounded">
+                                                        <div className="flex-1">
+                                                            <input
+                                                                type="text"
+                                                                value={contact.name}
+                                                                onChange={(e) => updateUncategorized(idx, 'name', e.target.value)}
+                                                                placeholder="Name"
+                                                                className={`block w-full rounded-md text-sm shadow-sm focus:ring-indigo-500 ${contactsErrors[`uncategorized.${idx}.name`] ? 'border-red-300' : 'border-gray-300'}`}
+                                                            />
+                                                        </div>
+                                                        <div className="flex-1">
+                                                            <input
+                                                                type="email"
+                                                                value={contact.value}
+                                                                onChange={(e) => updateUncategorized(idx, 'value', e.target.value)}
+                                                                placeholder="Email"
+                                                                className={`block w-full rounded-md text-sm shadow-sm focus:ring-indigo-500 ${contactsErrors[`uncategorized.${idx}.value`] ? 'border-red-300' : 'border-gray-300'}`}
+                                                            />
+                                                        </div>
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => removeUncategorized(idx)}
                                                             className="text-red-400 hover:text-red-600"
                                                         >
                                                             <XIcon />

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,16 @@ Route::middleware(['auth'])->group(function () {
     // Customer detail page (must come after /customers/create)
     Route::get('/customers/{id}', [ActiveCustomersController::class, 'show'])->name('customers.show');
     Route::put('/customers/{id}/company-urls', [ActiveCustomersController::class, 'updateCompanyUrls'])->name('customers.update-company-urls');
+    // Local contact management for customers
+    Route::post('/customers/{id}/contacts', [ActiveCustomersController::class, 'createLocalContact'])->name('customers.contacts.create');
+    Route::put('/customers/{customerId}/contacts/{contactId}', [ActiveCustomersController::class, 'updateLocalContact'])->name('customers.contacts.update');
+    Route::delete('/customers/{customerId}/contacts/{contactId}', [ActiveCustomersController::class, 'deleteLocalContact'])->name('customers.contacts.delete');
+    Route::patch('/customers/{customerId}/contacts/{contactId}/categorize', [ActiveCustomersController::class, 'categorizeContact'])->name('customers.contacts.categorize');
+    // Broker management for customers
+    Route::put('/customers/{id}/broker', [ActiveCustomersController::class, 'updateBroker'])->name('customers.broker.update');
+    Route::post('/customers/{id}/broker-contacts', [ActiveCustomersController::class, 'createBrokerContact'])->name('customers.broker-contacts.create');
+    Route::put('/customers/{customerId}/broker-contacts/{contactId}', [ActiveCustomersController::class, 'updateBrokerContact'])->name('customers.broker-contacts.update');
+    Route::delete('/customers/{customerId}/broker-contacts/{contactId}', [ActiveCustomersController::class, 'deleteBrokerContact'])->name('customers.broker-contacts.delete');
 
     // Prospects (create route must come before {id} wildcard)
     Route::get('/prospects', [ProspectController::class, 'index'])->name('prospects.index');
@@ -32,6 +42,7 @@ Route::middleware(['auth'])->group(function () {
     Route::patch('/prospects/{id}/status', [ProspectController::class, 'updateStatus'])->name('prospects.update-status');
     Route::get('/prospects/{id}', [ProspectController::class, 'show'])->name('prospects.show');
     Route::put('/prospects/{id}', [ProspectController::class, 'update'])->name('prospects.update');
+    Route::patch('/prospects/{prospectId}/contacts/{contactId}/categorize', [ProspectController::class, 'categorizeContact'])->name('prospects.contacts.categorize');
 
     // Accounts Receivable
     Route::get('/accounts-receivable', [AccountsReceivableController::class, 'index'])->name('ar.index');


### PR DESCRIPTION
## Summary
- **Contact Discovery**: Automatically discover new contacts from Gmail emails and store as "uncategorized" type that users can categorize as Buyer/AP/Logistics
- **Broker Support**: Add broker company name, commission percentage, and broker contacts to both prospects and customers with full email tracking
- **Fulfil Integration**: Parse and format broker contacts using "Broker (Company Name): Contact Name" format for sync with Fulfil ERP

## Changes
### Database
- New `fulfil_uncategorized_contacts` table for customer uncategorized contacts
- New `fulfil_broker_contacts` table for customer broker contacts
- Added broker fields (`broker`, `broker_commission`, `broker_company_name`) to prospects and customer metadata tables

### Backend
- Updated `GmailService` to match broker emails exactly (not by domain) and track email activity
- Updated `FulfilService` to parse/format broker contacts in Fulfil format
- Added broker management endpoints to `ActiveCustomersController` and `ProspectController`
- Added contact categorization endpoint for prospects

### Frontend
- Added uncategorized contacts section with categorization dropdown
- Added broker section with company name, commission, and contacts management
- Full CRUD for broker contacts with email tracking display

## Test plan
- [ ] Create a prospect with broker enabled, add broker company name, commission, and contacts
- [ ] Verify broker section displays correctly in read/edit modes
- [ ] Verify Gmail sync discovers and tracks broker contact emails
- [ ] Verify Fulfil sync formats broker contacts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)