### PR TITLE
Fix undefined canManageCustomers method on User model

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -91,6 +91,14 @@ class User extends Authenticatable
     }
 
     /**
+     * Check if user can manage customers (salesperson or admin)
+     */
+    public function canManageCustomers(): bool
+    {
+        return $this->isAdmin() || $this->isSalesperson();
+    }
+
+    /**
      * Check if user has a specific role
      */
     public function hasRole(string $role): bool

--- a/tests/Feature/CustomerSkuControllerTest.php
+++ b/tests/Feature/CustomerSkuControllerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+use App\Models\CustomerSku;
+use App\Models\LocalCustomerMetadata;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->customerMetadata = LocalCustomerMetadata::create([
+        'fulfil_party_id' => 1001,
+        'company_urls' => [],
+    ]);
+});
+
+test('admin can list customer skus', function () {
+    $user = User::factory()->create(['role' => User::ROLE_ADMIN]);
+
+    CustomerSku::create([
+        'fulfil_party_id' => 1001,
+        'yums_sku' => 'YUMS-001',
+        'customer_sku' => 'CUST-001',
+    ]);
+
+    $response = $this->actingAs($user)->getJson('/customers/1001/skus');
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'skus');
+});
+
+test('salesperson can list customer skus', function () {
+    $user = User::factory()->create(['role' => User::ROLE_SALESPERSON]);
+
+    $response = $this->actingAs($user)->getJson('/customers/1001/skus');
+
+    $response->assertOk();
+});
+
+test('basic user cannot list customer skus', function () {
+    $user = User::factory()->create(['role' => User::ROLE_USER]);
+
+    $response = $this->actingAs($user)->getJson('/customers/1001/skus');
+
+    $response->assertStatus(403);
+});
+
+test('admin can create customer sku', function () {
+    $user = User::factory()->create(['role' => User::ROLE_ADMIN]);
+
+    $response = $this->actingAs($user)->postJson('/customers/1001/skus', [
+        'yums_sku' => 'YUMS-002',
+        'customer_sku' => 'CUST-002',
+    ]);
+
+    $response->assertStatus(201);
+    $this->assertDatabaseHas('customer_skus', [
+        'fulfil_party_id' => 1001,
+        'yums_sku' => 'YUMS-002',
+        'customer_sku' => 'CUST-002',
+    ]);
+});
+
+test('salesperson can create customer sku', function () {
+    $user = User::factory()->create(['role' => User::ROLE_SALESPERSON]);
+
+    $response = $this->actingAs($user)->postJson('/customers/1001/skus', [
+        'yums_sku' => 'YUMS-003',
+        'customer_sku' => 'CUST-003',
+    ]);
+
+    $response->assertStatus(201);
+});
+
+test('basic user cannot create customer sku', function () {
+    $user = User::factory()->create(['role' => User::ROLE_USER]);
+
+    $response = $this->actingAs($user)->postJson('/customers/1001/skus', [
+        'yums_sku' => 'YUMS-004',
+        'customer_sku' => 'CUST-004',
+    ]);
+
+    $response->assertStatus(403);
+});
+
+test('admin can update customer sku', function () {
+    $user = User::factory()->create(['role' => User::ROLE_ADMIN]);
+
+    $sku = CustomerSku::create([
+        'fulfil_party_id' => 1001,
+        'yums_sku' => 'YUMS-005',
+        'customer_sku' => 'CUST-005',
+    ]);
+
+    $response = $this->actingAs($user)->putJson("/customers/1001/skus/{$sku->id}", [
+        'customer_sku' => 'CUST-005-UPDATED',
+    ]);
+
+    $response->assertOk();
+    $this->assertDatabaseHas('customer_skus', [
+        'id' => $sku->id,
+        'customer_sku' => 'CUST-005-UPDATED',
+    ]);
+});
+
+test('basic user cannot update customer sku', function () {
+    $user = User::factory()->create(['role' => User::ROLE_USER]);
+
+    $sku = CustomerSku::create([
+        'fulfil_party_id' => 1001,
+        'yums_sku' => 'YUMS-006',
+        'customer_sku' => 'CUST-006',
+    ]);
+
+    $response = $this->actingAs($user)->putJson("/customers/1001/skus/{$sku->id}", [
+        'customer_sku' => 'CUST-006-UPDATED',
+    ]);
+
+    $response->assertStatus(403);
+});
+
+test('admin can delete customer sku', function () {
+    $user = User::factory()->create(['role' => User::ROLE_ADMIN]);
+
+    $sku = CustomerSku::create([
+        'fulfil_party_id' => 1001,
+        'yums_sku' => 'YUMS-007',
+        'customer_sku' => 'CUST-007',
+    ]);
+
+    $response = $this->actingAs($user)->deleteJson("/customers/1001/skus/{$sku->id}");
+
+    $response->assertOk();
+    $this->assertDatabaseMissing('customer_skus', ['id' => $sku->id]);
+});
+
+test('basic user cannot delete customer sku', function () {
+    $user = User::factory()->create(['role' => User::ROLE_USER]);
+
+    $sku = CustomerSku::create([
+        'fulfil_party_id' => 1001,
+        'yums_sku' => 'YUMS-008',
+        'customer_sku' => 'CUST-008',
+    ]);
+
+    $response = $this->actingAs($user)->deleteJson("/customers/1001/skus/{$sku->id}");
+
+    $response->assertStatus(403);
+});

--- a/tests/Unit/UserCanManageCustomersTest.php
+++ b/tests/Unit/UserCanManageCustomersTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Models\User;
+
+test('admin can manage customers', function () {
+    $user = User::factory()->create(['role' => User::ROLE_ADMIN]);
+
+    expect($user->canManageCustomers())->toBeTrue();
+});
+
+test('salesperson can manage customers', function () {
+    $user = User::factory()->create(['role' => User::ROLE_SALESPERSON]);
+
+    expect($user->canManageCustomers())->toBeTrue();
+});
+
+test('basic user cannot manage customers', function () {
+    $user = User::factory()->create(['role' => User::ROLE_USER]);
+
+    expect($user->canManageCustomers())->toBeFalse();
+});


### PR DESCRIPTION
## Summary
- Added missing `canManageCustomers()` method to the User model that was being called by `CustomerSkuController`, causing 500 errors on all SKU management endpoints
- The method grants access to admins and salespersons, matching the existing role-based access pattern used by `canAccessGmailIntegration()`
- Added unit tests verifying correct return values for each role (admin, salesperson, user)
- Added feature tests for all four CustomerSkuController endpoints (index, store, update, destroy) verifying admin/salesperson access and basic user 403 rejection

## Test plan
- [x] Unit tests verify `canManageCustomers()` returns `true` for admin, `true` for salesperson, `false` for basic user
- [x] Feature tests verify admin can list, create, update, and delete customer SKUs
- [x] Feature tests verify salesperson can list and create customer SKUs
- [x] Feature tests verify basic user gets 403 on all SKU endpoints
- [x] All 20 tests pass with `php artisan test --compact`