### PR TITLE
Sanitize HTML rendering to prevent XSS

### DIFF
--- a/app/Services/ArEmailService.php
+++ b/app/Services/ArEmailService.php
@@ -124,7 +124,7 @@ class ArEmailService
      */
     public function sendSkuMappingError(array $customerData, array $unmappedSkus): bool
     {
-        $formattedSkus = '<ul>'.implode('', array_map(fn ($sku) => "<li>{$sku}</li>", $unmappedSkus)).'</ul>';
+        $formattedSkus = '<ul>'.implode('', array_map(fn ($sku) => '<li>'.e($sku).'</li>', $unmappedSkus)).'</ul>';
 
         return $this->send(
             EmailTemplate::TYPE_SKU_MAPPING_ERROR,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "sales",
+    "name": "uy-sales",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -12,6 +12,7 @@
                 "@radix-ui/react-tooltip": "^1.2.8",
                 "clsx": "^2.1.1",
                 "date-fns": "^4.1.0",
+                "dompurify": "^3.3.3",
                 "lucide-react": "^0.577.0",
                 "recharts": "^3.8.0"
             },
@@ -26,6 +27,7 @@
                 "@types/babel__generator": "^7.27.0",
                 "@types/babel__template": "^7.4.4",
                 "@types/babel__traverse": "^7.28.0",
+                "@types/dompurify": "^3.0.5",
                 "@types/lodash": "^4.17.24",
                 "@types/node": "^22.12.0",
                 "@types/prop-types": "^15.7.15",
@@ -78,7 +80,6 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -2572,6 +2573,16 @@
             "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
             "license": "MIT"
         },
+        "node_modules/@types/dompurify": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+            "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/trusted-types": "*"
+            }
+        },
         "node_modules/@types/lodash": {
             "version": "4.17.24",
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
@@ -2595,7 +2606,6 @@
             "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -2613,7 +2623,6 @@
             "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -2625,10 +2634,16 @@
             "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^18.0.0"
             }
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "devOptional": true,
+            "license": "MIT"
         },
         "node_modules/@types/use-sync-external-store": {
             "version": "0.0.6",
@@ -3298,6 +3313,15 @@
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/dompurify": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+            "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
+            }
         },
         "node_modules/es-toolkit": {
             "version": "1.45.1",
@@ -4587,7 +4611,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -4793,7 +4816,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -4806,7 +4828,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -4827,7 +4848,6 @@
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
             "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/use-sync-external-store": "^0.0.6",
                 "use-sync-external-store": "^1.4.0"
@@ -4977,8 +4997,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
             "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/redux-thunk": {
             "version": "3.1.0",
@@ -5667,7 +5686,6 @@
             "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
@@ -5873,7 +5891,6 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "@types/babel__generator": "^7.27.0",
         "@types/babel__template": "^7.4.4",
         "@types/babel__traverse": "^7.28.0",
+        "@types/dompurify": "^3.0.5",
         "@types/lodash": "^4.17.24",
         "@types/node": "^22.12.0",
         "@types/prop-types": "^15.7.15",
@@ -42,6 +43,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "dompurify": "^3.3.3",
         "lucide-react": "^0.577.0",
         "recharts": "^3.8.0"
     }

--- a/resources/js/Components/EmailDetailModal.tsx
+++ b/resources/js/Components/EmailDetailModal.tsx
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 import { useState, useEffect } from 'react';
 import Modal from './Modal';
 
@@ -276,7 +277,7 @@ export default function EmailDetailModal({ entityType, entityId, emailId, onClos
                                 {activeEmail.body_html ? (
                                     <div
                                         className="prose prose-sm max-w-none email-content"
-                                        dangerouslySetInnerHTML={{ __html: activeEmail.body_html }}
+                                        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(activeEmail.body_html, { ADD_ATTR: ['target'] }) }}
                                     />
                                 ) : activeEmail.body_text ? (
                                     <pre className="whitespace-pre-wrap text-sm text-gray-700 font-sans">

--- a/resources/js/Pages/Admin/EmailTemplates.tsx
+++ b/resources/js/Pages/Admin/EmailTemplates.tsx
@@ -1,5 +1,6 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { Head } from '@inertiajs/react';
+import DOMPurify from 'dompurify';
 import { useState, useRef, useEffect } from 'react';
 
 interface Template {
@@ -38,7 +39,7 @@ export default function EmailTemplates({ templates }: Props) {
     // Update contenteditable when body changes programmatically
     useEffect(() => {
         if (editorRef.current && editorRef.current.innerHTML !== body) {
-            editorRef.current.innerHTML = body;
+            editorRef.current.innerHTML = DOMPurify.sanitize(body);
         }
     }, [body]);
 
@@ -300,7 +301,7 @@ export default function EmailTemplates({ templates }: Props) {
                                                 </div>
                                                 <div
                                                     className="prose prose-sm max-w-none"
-                                                    dangerouslySetInnerHTML={{ __html: body }}
+                                                    dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(body, { ADD_ATTR: ['target'] }) }}
                                                 />
                                             </div>
                                         </div>


### PR DESCRIPTION
## Summary

The Gmail integration syncs emails from external senders and stores their raw HTML body. When a salesperson views an email in the app, that HTML was rendered directly via `dangerouslySetInnerHTML` with no sanitization. A malicious sender could craft an email containing `<script>` tags, `<img onerror="...">` handlers, or CSS-based exfiltration that would execute in the context of our app when opened — giving them access to the user's session, CSRF tokens, and any data visible on the page.

This PR adds [DOMPurify](https://github.com/cure53/DOMPurify) to sanitize all HTML before rendering, and escapes server-side HTML interpolation as defense-in-depth.

## Changes
- **EmailDetailModal.tsx**: DOMPurify sanitizes `body_html` from Gmail-synced emails before rendering
- **EmailTemplates.tsx**: DOMPurify sanitizes template body in preview panel and contentEditable editor
- **ArEmailService.php**: `e()` escapes SKU strings interpolated into `<li>` HTML tags
- **package.json**: Added `dompurify` + `@types/dompurify`

## Test plan
- [ ] View a Gmail email in the email detail modal — verify HTML renders correctly
- [ ] Check that email links with `target="_blank"` still open in new tabs
- [ ] Edit an email template in admin — verify preview renders correctly
- [ ] Trigger a SKU mapping error email — verify SKUs display correctly