### PR TITLE
Add dev:herd composer script for Laravel Herd users

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,10 @@
             "Composer\\Config::disableProcessTimeout",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
         ],
+        "dev:herd": [
+            "Composer\\Config::disableProcessTimeout",
+            "npx concurrently -c \"#c4b5fd,#fb7185,#fdba74\" \"php artisan queue:listen --tries=1 --timeout=0\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=queue,logs,vite --kill-others"
+        ],
         "test": [
             "@php artisan config:clear --ansi",
             "@php artisan test"


### PR DESCRIPTION
### Which issue does this close?

N/A

### Write a short description of code change.

Adds a `dev:herd` composer script that runs everything except `php artisan serve`. This is useful for developers using Laravel Herd, which already serves PHP via Nginx. The existing `dev` script remains unchanged, so non-Herd developers are unaffected.
