### PR TITLE
Fix: email template UI not reflecting saved changes

### DIFF
--- a/resources/js/Pages/Admin/EmailTemplates.tsx
+++ b/resources/js/Pages/Admin/EmailTemplates.tsx
@@ -28,15 +28,6 @@ export default function EmailTemplates({ templates }: Props) {
     const [showPreview, setShowPreview] = useState(false);
     const editorRef = useRef<HTMLDivElement>(null);
 
-    // Reset local state when server provides fresh template data (e.g. Inertia re-navigation)
-    useEffect(() => {
-        setLocalTemplates(templates);
-        const first = templates[0];
-        setSelectedKey(first?.key || '');
-        setSubject(first?.subject || '');
-        setBody(first?.body || '');
-    }, [templates]);
-
     const selectedTemplate = localTemplates.find(t => t.key === selectedKey);
 
     const handleTemplateChange = (key: string) => {


### PR DESCRIPTION
## Summary
- Store templates in local component state so saved values persist when switching between templates
- Update local state after successful save, eliminating the need for a page refresh
- Switch from `fetch()` to `axios` per project conventions (automatic CSRF handling)
- Preserve server-provided error messages instead of always showing a generic fallback
- Replace `useEffect` with an event handler for template switching, following React's guidance of handling user actions in handlers rather than effects
- Initialize `subject` and `body` directly from props, removing the mount-only `useEffect` and its eslint-disable comment

Closes #18

## Test plan
- [ ] Go to `/admin/email-templates`, select a template, edit its subject and body, click "Save Template" — verify the success notification appears
- [ ] Without reloading the page, switch to a different template using the dropdown, then switch back to the one you just edited — verify your saved changes are still there
- [ ] Clear the subject field and click "Save Template" — verify a validation error is displayed
- [ ] Enter a valid subject, click "Save Template" again — verify it saves successfully