### PR TITLE
Add parallel test execution with paratest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,4 +52,4 @@ jobs:
         run: php artisan migrate --force
 
       - name: Tests
-        run: ./vendor/bin/pest
+        run: php artisan test --parallel

--- a/claude.md
+++ b/claude.md
@@ -35,7 +35,7 @@ Admin (full access + user management), Salesperson (prospects + customers + Gmai
 
 ```bash
 composer run dev              # Full dev environment (server + queue + logs + Vite)
-php artisan test --compact    # Run tests (use --filter to target specific tests)
+php artisan test --parallel    # Run tests (use --filter to target specific tests)
 vendor/bin/pint --dirty       # Format PHP before finalizing changes
 npm run build                 # Production frontend build
 npm run lint                  # ESLint

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "tightenco/ziggy": "^2.0"
     },
     "require-dev": {
+        "brianium/paratest": "^7.19",
         "fakerphp/faker": "^1.23",
         "laravel/breeze": "^2.4",
         "laravel/pail": "^1.2.2",
@@ -59,7 +60,7 @@
         ],
         "test": [
             "@php artisan config:clear --ansi",
-            "@php artisan test"
+            "@php artisan test --parallel"
         ],
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "675b56e8cfe8b552b50b3a1ba06d2743",
+    "content-hash": "045652e157d9a22b254785f90447f9d7",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",


### PR DESCRIPTION
Closes #31

## Summary

- Install `brianium/paratest` for parallel test execution
- Update `composer.json` test script to use `--parallel` flag
- Update GitHub Actions test workflow to run tests in parallel
- Update CLAUDE.md test command reference

Tests run across 8 processes, completing in ~1s locally.
This is not a major improvement yet, since the test suite is still relatively small, but I decided to make the change now as part of bringing some good patterns over from PIM’s codebase.

## Test plan

- [x] `php artisan test --parallel` — 146 passed (8 processes, 1.10s)
- [x] `vendor/bin/pint --test` — passes