### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+### Which issue does this close?
+
+Closes #
+
+### Write a short description of code change.
+
+- Explain the code changes.
+- Post screenshots for any visual changes.
+- For complex features, include a Loom video.
+
+### How should these changes be tested?
+
+List steps to test this code for reviewer.
+
+- [ ] Instructions to test first item.
+- [ ] ...
+
+### Steps taken before assigning the PR.
+
+- [ ] Reviewed the changeset in this PR.
+- [ ] Initial code review by Claude.


### PR DESCRIPTION
Closes #33

### Which issue does this close?

N/A

### Write a short description of code change.

- Adds a PR template matching the PIM repo's template so all PRs follow the same structure.

### How should these changes be tested?

- [ ] Open a new PR and verify the template auto-populates.

### Steps taken before assigning the PR.

- [x] Reviewed the changeset in this PR.
- [x] Initial code review by Claude.