### PR TITLE
Replace all fetch() calls with axios

### DIFF
--- a/resources/js/Components/EmailActivityPanel.tsx
+++ b/resources/js/Components/EmailActivityPanel.tsx
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { useState, useEffect } from 'react';
 import EmailDetailModal from './EmailDetailModal';
 
@@ -114,25 +115,14 @@ export default function EmailActivityPanel({ entityType, entityId }: Props) {
                 ? route('prospects.emails', { id: entityId, per_page: 10, page })
                 : route('customers.emails', { id: entityId, per_page: 10, page });
 
-            const response = await fetch(url, {
-                headers: {
-                    'Accept': 'application/json',
-                    'X-Requested-With': 'XMLHttpRequest',
-                },
-            });
-
-            if (!response.ok) {
-                throw new Error('Failed to fetch emails');
-            }
-
-            const data = await response.json();
+            const response = await axios.get(url);
 
             if (page === 1) {
-                setEmails(data.emails);
+                setEmails(response.data.emails);
             } else {
-                setEmails(prev => [...prev, ...data.emails]);
+                setEmails(prev => [...prev, ...response.data.emails]);
             }
-            setPagination(data.pagination);
+            setPagination(response.data.pagination);
         } catch (err) {
             setError('Failed to load emails');
             console.error('Error fetching emails:', err);

--- a/resources/js/Components/EmailDetailModal.tsx
+++ b/resources/js/Components/EmailDetailModal.tsx
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import DOMPurify from 'dompurify';
 import { useState, useEffect } from 'react';
 import Modal from './Modal';
@@ -103,20 +104,9 @@ export default function EmailDetailModal({ entityType, entityId, emailId, onClos
                     ? route('prospects.emails.show', { prospectId: entityId, emailId })
                     : route('customers.emails.show', { customerId: entityId, emailId });
 
-                const response = await fetch(url, {
-                    headers: {
-                        'Accept': 'application/json',
-                        'X-Requested-With': 'XMLHttpRequest',
-                    },
-                });
-
-                if (!response.ok) {
-                    throw new Error('Failed to fetch email');
-                }
-
-                const data = await response.json();
-                setEmail(data.email);
-                setThread(data.thread || []);
+                const response = await axios.get(url);
+                setEmail(response.data.email);
+                setThread(response.data.thread || []);
             } catch (err) {
                 setError('Failed to load email');
                 console.error('Error fetching email:', err);

--- a/resources/js/Pages/AccountsReceivable/Index.tsx
+++ b/resources/js/Pages/AccountsReceivable/Index.tsx
@@ -1,5 +1,6 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { Head, router } from '@inertiajs/react';
+import axios from 'axios';
 import { useState, Fragment } from 'react';
 import { Menu, Transition } from '@headlessui/react';
 
@@ -111,25 +112,15 @@ export default function Index({ customers, totals, search, lastUpdated, fulfilSu
         setMessage(null);
 
         try {
-            const response = await fetch(route('invoices.pdf.regenerate', { id: invoiceId }), {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-            });
-
-            const data = await response.json();
-
-            if (response.ok) {
-                setMessage({ type: 'success', text: 'PDF regenerated successfully' });
-                // Open the newly generated PDF
-                window.open(route('invoices.pdf.download', { id: invoiceId }), '_blank');
-            } else {
-                setMessage({ type: 'error', text: data.message || 'Failed to regenerate PDF' });
-            }
+            await axios.post(route('invoices.pdf.regenerate', { id: invoiceId }));
+            setMessage({ type: 'success', text: 'PDF regenerated successfully' });
+            window.open(route('invoices.pdf.download', { id: invoiceId }), '_blank');
         } catch (error) {
-            setMessage({ type: 'error', text: 'Failed to regenerate PDF' });
+            if (axios.isAxiosError(error)) {
+                setMessage({ type: 'error', text: error.response?.data?.message || 'Failed to regenerate PDF' });
+            } else {
+                setMessage({ type: 'error', text: 'Failed to regenerate PDF' });
+            }
         } finally {
             setRegeneratingPdf(null);
             setTimeout(() => setMessage(null), 5000);
@@ -143,24 +134,14 @@ export default function Index({ customers, totals, search, lastUpdated, fulfilSu
         setMessage(null);
 
         try {
-            const response = await fetch(route('invoices.resend-email', { id: invoiceId }), {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({ email_type: emailType }),
-            });
-
-            const data = await response.json();
-
-            if (response.ok) {
-                setMessage({ type: 'success', text: `Email sent successfully` });
-            } else {
-                setMessage({ type: 'error', text: data.message || 'Failed to send email' });
-            }
+            await axios.post(route('invoices.resend-email', { id: invoiceId }), { email_type: emailType });
+            setMessage({ type: 'success', text: `Email sent successfully` });
         } catch (error) {
-            setMessage({ type: 'error', text: 'Failed to send email' });
+            if (axios.isAxiosError(error)) {
+                setMessage({ type: 'error', text: error.response?.data?.message || 'Failed to send email' });
+            } else {
+                setMessage({ type: 'error', text: 'Failed to send email' });
+            }
         } finally {
             setSendingEmail(null);
             setTimeout(() => setMessage(null), 5000);

--- a/resources/js/Pages/ActiveCustomers/Show.tsx
+++ b/resources/js/Pages/ActiveCustomers/Show.tsx
@@ -1,6 +1,7 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import EmailActivityPanel from '@/Components/EmailActivityPanel';
 import { Head, Link, router, usePage } from '@inertiajs/react';
+import axios from 'axios';
 import { useState, useEffect } from 'react';
 
 interface Contact {
@@ -600,38 +601,29 @@ export default function Show({
         try {
             // Save customer details and AR settings in a single request
             // so they're written to Fulfil atomically (avoiding metafield race conditions)
-            const response = await fetch(route('customers.update', customer.id), {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({
-                    name: detailsForm.name,
-                    sale_price_list: parseInt(detailsForm.sale_price_list),
-                    customer_payment_term: parseInt(detailsForm.customer_payment_term),
-                    shipping_terms_category_id: parseInt(detailsForm.shipping_terms_category_id),
-                    shelf_life_requirement: parseInt(detailsForm.shelf_life_requirement),
-                    vendor_guide: detailsForm.vendor_guide || null,
-                    // AR settings (saved atomically with party data)
-                    ar_edi: arSettingsForm.edi,
-                    ar_consolidated_invoicing: arSettingsForm.consolidated_invoicing,
-                    ar_requires_customer_skus: arSettingsForm.requires_customer_skus,
-                    ar_invoice_discount: arSettingsForm.invoice_discount ? parseFloat(arSettingsForm.invoice_discount) : null,
-                    // Note: broker is updated via the broker section, not here
-                }),
+            await axios.put(route('customers.update', customer.id), {
+                name: detailsForm.name,
+                sale_price_list: parseInt(detailsForm.sale_price_list),
+                customer_payment_term: parseInt(detailsForm.customer_payment_term),
+                shipping_terms_category_id: parseInt(detailsForm.shipping_terms_category_id),
+                shelf_life_requirement: parseInt(detailsForm.shelf_life_requirement),
+                vendor_guide: detailsForm.vendor_guide || null,
+                // AR settings (saved atomically with party data)
+                ar_edi: arSettingsForm.edi,
+                ar_consolidated_invoicing: arSettingsForm.consolidated_invoicing,
+                ar_requires_customer_skus: arSettingsForm.requires_customer_skus,
+                ar_invoice_discount: arSettingsForm.invoice_discount ? parseFloat(arSettingsForm.invoice_discount) : null,
+                // Note: broker is updated via the broker section, not here
             });
-
-            if (response.ok) {
-                setEditingDetails(false);
-                setNotification({ type: 'success', message: 'Customer details updated successfully' });
-                router.reload({ only: ['customer'] });
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to save changes' });
-            }
+            setEditingDetails(false);
+            setNotification({ type: 'success', message: 'Customer details updated successfully' });
+            router.reload({ only: ['customer'] });
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to save changes. Please try again.' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to save changes' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to save changes. Please try again.' });
+            }
         } finally {
             setSaving(false);
         }
@@ -649,33 +641,24 @@ export default function Show({
 
         setSaving(true);
         try {
-            const response = await fetch(route('customers.update', customer.id), {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({
-                    buyers: contactsForm.buyers,
-                    accounts_payable: accountsPayable,
-                    other: contactsForm.other.map(o => ({
-                        name: o.name,
-                        email: o.email,
-                        function: o.function || '',
-                    })),
-                }),
+            await axios.put(route('customers.update', customer.id), {
+                buyers: contactsForm.buyers,
+                accounts_payable: accountsPayable,
+                other: contactsForm.other.map(o => ({
+                    name: o.name,
+                    email: o.email,
+                    function: o.function || '',
+                })),
             });
-
-            if (response.ok) {
-                setEditingContacts(false);
-                setNotification({ type: 'success', message: 'Contacts updated successfully' });
-                router.reload({ only: ['customer', 'buyerContacts', 'localBuyers', 'localAP', 'localOther'] });
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to save changes' });
-            }
+            setEditingContacts(false);
+            setNotification({ type: 'success', message: 'Contacts updated successfully' });
+            router.reload({ only: ['customer', 'buyerContacts', 'localBuyers', 'localAP', 'localOther'] });
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to save changes. Please try again.' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to save changes' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to save changes. Please try again.' });
+            }
         } finally {
             setSaving(false);
         }
@@ -691,30 +674,20 @@ export default function Show({
 
         setAddingSku(true);
         try {
-            const response = await fetch(route('customers.skus.store', customer.id), {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({
-                    yums_sku: newSkuYums,
-                    customer_sku: newSkuCustomer,
-                }),
+            const response = await axios.post(route('customers.skus.store', customer.id), {
+                yums_sku: newSkuYums,
+                customer_sku: newSkuCustomer,
             });
-
-            if (response.ok) {
-                const data = await response.json();
-                setCustomerSkus(prev => [...prev, data.sku]);
-                setNewSkuYums('');
-                setNewSkuCustomer('');
-                setNotification({ type: 'success', message: 'SKU mapping added successfully' });
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to add SKU mapping' });
-            }
+            setCustomerSkus(prev => [...prev, response.data.sku]);
+            setNewSkuYums('');
+            setNewSkuCustomer('');
+            setNotification({ type: 'success', message: 'SKU mapping added successfully' });
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to add SKU mapping. Please try again.' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to add SKU mapping' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to add SKU mapping. Please try again.' });
+            }
         } finally {
             setAddingSku(false);
         }
@@ -724,22 +697,15 @@ export default function Show({
         if (!confirm('Are you sure you want to delete this SKU mapping?')) return;
 
         try {
-            const response = await fetch(route('customers.skus.destroy', { customerId: customer.id, skuId }), {
-                method: 'DELETE',
-                headers: {
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-            });
-
-            if (response.ok) {
-                setCustomerSkus(prev => prev.filter(s => s.id !== skuId));
-                setNotification({ type: 'success', message: 'SKU mapping deleted successfully' });
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to delete SKU mapping' });
-            }
+            await axios.delete(route('customers.skus.destroy', { customerId: customer.id, skuId }));
+            setCustomerSkus(prev => prev.filter(s => s.id !== skuId));
+            setNotification({ type: 'success', message: 'SKU mapping deleted successfully' });
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to delete SKU mapping. Please try again.' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to delete SKU mapping' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to delete SKU mapping. Please try again.' });
+            }
         }
     };
 
@@ -758,29 +724,13 @@ export default function Show({
         try {
             setNotification({ type: 'success', message: `Regenerating PDF for invoice ${invoiceNumber || invoiceId}...` });
 
-            const response = await fetch(route('invoices.pdf.regenerate', { id: invoiceId }), {
-                method: 'POST',
-                headers: {
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                    'Accept': 'application/pdf',
-                },
+            const response = await axios.post(route('invoices.pdf.regenerate', { id: invoiceId }), {}, {
+                responseType: 'blob',
+                headers: { 'Accept': 'application/pdf' },
             });
 
-            if (!response.ok) {
-                const errorData = await response.json().catch(() => ({ message: 'Failed to regenerate PDF' }));
-                if (errorData.error === 'sku_mapping_required' && errorData.unmapped_skus) {
-                    setNotification({
-                        type: 'error',
-                        message: `Cannot generate PDF: unmapped SKUs: ${errorData.unmapped_skus.join(', ')}. Please add the missing SKU mappings.`
-                    });
-                } else {
-                    setNotification({ type: 'error', message: errorData.message || 'Failed to regenerate PDF' });
-                }
-                return;
-            }
-
             // Handle the PDF blob response
-            const blob = await response.blob();
+            const blob = new Blob([response.data], { type: 'application/pdf' });
             const url = window.URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
@@ -792,8 +742,31 @@ export default function Show({
 
             setNotification({ type: 'success', message: `PDF regenerated for invoice ${invoiceNumber || invoiceId}` });
         } catch (error) {
-            console.error('Error regenerating PDF:', error);
-            setNotification({ type: 'error', message: 'Failed to regenerate PDF. Please try again.' });
+            if (axios.isAxiosError(error)) {
+                // When responseType is 'blob', error response data is also a blob — parse it
+                const errorData = error.response?.data;
+                if (errorData instanceof Blob) {
+                    try {
+                        const text = await errorData.text();
+                        const parsed = JSON.parse(text);
+                        if (parsed.error === 'sku_mapping_required' && parsed.unmapped_skus) {
+                            setNotification({
+                                type: 'error',
+                                message: `Cannot generate PDF: unmapped SKUs: ${parsed.unmapped_skus.join(', ')}. Please add the missing SKU mappings.`
+                            });
+                        } else {
+                            setNotification({ type: 'error', message: parsed.message || 'Failed to regenerate PDF' });
+                        }
+                    } catch {
+                        setNotification({ type: 'error', message: 'Failed to regenerate PDF' });
+                    }
+                } else {
+                    setNotification({ type: 'error', message: errorData?.message || 'Failed to regenerate PDF' });
+                }
+            } else {
+                console.error('Error regenerating PDF:', error);
+                setNotification({ type: 'error', message: 'Failed to regenerate PDF. Please try again.' });
+            }
         }
     };
 
@@ -871,25 +844,16 @@ export default function Show({
         if (!contactId || !newType) return;
 
         try {
-            const response = await fetch(route('customers.contacts.categorize', { customerId: customer.id, contactId }), {
-                method: 'PATCH',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({ type: newType }),
-            });
-
-            if (response.ok) {
-                setCategorizingContacts({});
-                setNotification({ type: 'success', message: 'Contact categorized successfully' });
-                router.reload();
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to categorize contact' });
-            }
+            await axios.patch(route('customers.contacts.categorize', { customerId: customer.id, contactId }), { type: newType });
+            setCategorizingContacts({});
+            setNotification({ type: 'success', message: 'Contact categorized successfully' });
+            router.reload();
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to categorize contact. Please try again.' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to categorize contact' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to categorize contact. Please try again.' });
+            }
         }
     };
 
@@ -898,22 +862,15 @@ export default function Show({
         if (!confirm('Are you sure you want to delete this contact?')) return;
 
         try {
-            const response = await fetch(route('customers.contacts.delete', { customerId: customer.id, contactId }), {
-                method: 'DELETE',
-                headers: {
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-            });
-
-            if (response.ok) {
-                setNotification({ type: 'success', message: 'Contact deleted successfully' });
-                router.reload();
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to delete contact' });
-            }
+            await axios.delete(route('customers.contacts.delete', { customerId: customer.id, contactId }));
+            setNotification({ type: 'success', message: 'Contact deleted successfully' });
+            router.reload();
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to delete contact. Please try again.' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to delete contact' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to delete contact. Please try again.' });
+            }
         }
     };
 
@@ -977,31 +934,21 @@ export default function Show({
     const saveBroker = async () => {
         setSaving(true);
         try {
-            // First update broker flag and commission
-            const brokerResponse = await fetch(route('customers.broker.update', customer.id), {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({
-                    broker: detailsForm.broker === 'true',
-                    broker_commission: detailsForm.broker_commission ? parseFloat(detailsForm.broker_commission) : null,
-                    broker_company_name: detailsForm.broker_company_name || null,
-                    broker_contacts: brokerContactsForm.filter(c => c.name.trim()),
-                }),
+            await axios.put(route('customers.broker.update', customer.id), {
+                broker: detailsForm.broker === 'true',
+                broker_commission: detailsForm.broker_commission ? parseFloat(detailsForm.broker_commission) : null,
+                broker_company_name: detailsForm.broker_company_name || null,
+                broker_contacts: brokerContactsForm.filter(c => c.name.trim()),
             });
-
-            if (brokerResponse.ok) {
-                setEditingBroker(false);
-                setNotification({ type: 'success', message: 'Broker settings updated successfully' });
-                router.reload();
-            } else {
-                const data = await brokerResponse.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to save broker settings' });
-            }
+            setEditingBroker(false);
+            setNotification({ type: 'success', message: 'Broker settings updated successfully' });
+            router.reload();
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to save broker settings. Please try again.' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to save broker settings' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to save broker settings. Please try again.' });
+            }
         } finally {
             setSaving(false);
         }
@@ -1013,25 +960,16 @@ export default function Show({
 
         setChangingCustomerType(true);
         try {
-            const response = await fetch(route('customers.update-customer-type', customer.id), {
-                method: 'PATCH',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({ customer_type: newType }),
-            });
-
-            if (response.ok) {
-                setCustomerType(newType);
-                setNotification({ type: 'success', message: `Customer type updated to ${newType}` });
-                router.reload();
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to update customer type' });
-            }
+            await axios.patch(route('customers.update-customer-type', customer.id), { customer_type: newType });
+            setCustomerType(newType);
+            setNotification({ type: 'success', message: `Customer type updated to ${newType}` });
+            router.reload();
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to update customer type' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to update customer type' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to update customer type' });
+            }
         } finally {
             setChangingCustomerType(false);
         }
@@ -1055,26 +993,16 @@ export default function Show({
 
         setAddingDistributorCustomer(true);
         try {
-            const response = await fetch(route('customers.distributor-customers.create', customer.id), {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({ name: newDistributorCustomerName.trim() }),
-            });
-
-            if (response.ok) {
-                const data = await response.json();
-                setLocalDistributorCustomers(prev => [...prev, data.distributor_customer]);
-                setNewDistributorCustomerName('');
-                setNotification({ type: 'success', message: 'Distributor customer added' });
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to add distributor customer' });
-            }
+            const response = await axios.post(route('customers.distributor-customers.create', customer.id), { name: newDistributorCustomerName.trim() });
+            setLocalDistributorCustomers(prev => [...prev, response.data.distributor_customer]);
+            setNewDistributorCustomerName('');
+            setNotification({ type: 'success', message: 'Distributor customer added' });
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to add distributor customer' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to add distributor customer' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to add distributor customer' });
+            }
         } finally {
             setAddingDistributorCustomer(false);
         }
@@ -1085,23 +1013,16 @@ export default function Show({
 
         setDeletingDC(true);
         try {
-            const response = await fetch(route('customers.distributor-customers.delete', { customerId: customer.id, distributorCustomerId: deleteConfirmDC.id }), {
-                method: 'DELETE',
-                headers: {
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-            });
-
-            if (response.ok) {
-                setLocalDistributorCustomers(prev => prev.filter(dc => dc.id !== deleteConfirmDC.id));
-                setDeleteConfirmDC(null);
-                setNotification({ type: 'success', message: 'Distributor customer deleted' });
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to delete' });
-            }
+            await axios.delete(route('customers.distributor-customers.delete', { customerId: customer.id, distributorCustomerId: deleteConfirmDC.id }));
+            setLocalDistributorCustomers(prev => prev.filter(dc => dc.id !== deleteConfirmDC.id));
+            setDeleteConfirmDC(null);
+            setNotification({ type: 'success', message: 'Distributor customer deleted' });
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to delete distributor customer' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to delete' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to delete distributor customer' });
+            }
         } finally {
             setDeletingDC(false);
         }
@@ -1109,27 +1030,19 @@ export default function Show({
 
     const updateDistributorCustomerUrls = async (dcId: number, urls: string[]) => {
         try {
-            const response = await fetch(route('customers.distributor-customers.update', { customerId: customer.id, distributorCustomerId: dcId }), {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({ company_urls: urls.filter(u => u.trim()) }),
+            const response = await axios.put(route('customers.distributor-customers.update', { customerId: customer.id, distributorCustomerId: dcId }), {
+                company_urls: urls.filter(u => u.trim()),
             });
-
-            if (response.ok) {
-                const data = await response.json();
-                setLocalDistributorCustomers(prev => prev.map(dc =>
-                    dc.id === dcId ? { ...dc, company_urls: data.distributor_customer.company_urls } : dc
-                ));
-                setNotification({ type: 'success', message: 'Domains updated' });
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to update domains' });
-            }
+            setLocalDistributorCustomers(prev => prev.map(dc =>
+                dc.id === dcId ? { ...dc, company_urls: response.data.distributor_customer.company_urls } : dc
+            ));
+            setNotification({ type: 'success', message: 'Domains updated' });
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to update domains' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to update domains' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to update domains' });
+            }
         }
     };
 
@@ -1151,31 +1064,21 @@ export default function Show({
 
         setSavingDC(true);
         try {
-            const response = await fetch(route('customers.distributor-customers.update', { customerId: customer.id, distributorCustomerId: editingDCId }), {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({
-                    name: editingDCName.trim(),
-                    company_urls: editingDCUrls.filter(u => u.trim()),
-                }),
+            const response = await axios.put(route('customers.distributor-customers.update', { customerId: customer.id, distributorCustomerId: editingDCId }), {
+                name: editingDCName.trim(),
+                company_urls: editingDCUrls.filter(u => u.trim()),
             });
-
-            if (response.ok) {
-                const data = await response.json();
-                setLocalDistributorCustomers(prev => prev.map(dc =>
-                    dc.id === editingDCId ? { ...dc, name: data.distributor_customer.name, company_urls: data.distributor_customer.company_urls } : dc
-                ));
-                setNotification({ type: 'success', message: 'Distributor customer updated' });
-                cancelEditingDC();
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to update' });
-            }
+            setLocalDistributorCustomers(prev => prev.map(dc =>
+                dc.id === editingDCId ? { ...dc, name: response.data.distributor_customer.name, company_urls: response.data.distributor_customer.company_urls } : dc
+            ));
+            setNotification({ type: 'success', message: 'Distributor customer updated' });
+            cancelEditingDC();
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to update distributor customer' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to update' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to update distributor customer' });
+            }
         } finally {
             setSavingDC(false);
         }
@@ -1199,28 +1102,18 @@ export default function Show({
 
         setAddingDCContact(true);
         try {
-            const response = await fetch(route('distributor-customers.contacts.create', { distributorCustomerId: dcId }), {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({ email: newDCContactEmail.trim() }),
-            });
-
-            if (response.ok) {
-                const data = await response.json();
-                setLocalDistributorCustomers(prev => prev.map(dc =>
-                    dc.id === dcId ? { ...dc, contacts: [...(dc.contacts || []), data.contact] } : dc
-                ));
-                setNewDCContactEmail('');
-                setNotification({ type: 'success', message: 'Contact added' });
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to add contact' });
-            }
+            const response = await axios.post(route('distributor-customers.contacts.create', { distributorCustomerId: dcId }), { email: newDCContactEmail.trim() });
+            setLocalDistributorCustomers(prev => prev.map(dc =>
+                dc.id === dcId ? { ...dc, contacts: [...(dc.contacts || []), response.data.contact] } : dc
+            ));
+            setNewDCContactEmail('');
+            setNotification({ type: 'success', message: 'Contact added' });
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to add contact' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to add contact' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to add contact' });
+            }
         } finally {
             setAddingDCContact(false);
         }
@@ -1243,34 +1136,24 @@ export default function Show({
 
         setSavingDCContact(true);
         try {
-            const response = await fetch(route('distributor-customers.contacts.update', { distributorCustomerId: dcId, contactId: editingDCContactId }), {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({
-                    name: editingDCContactName.trim(),
-                    type: editingDCContactType,
-                }),
+            const response = await axios.put(route('distributor-customers.contacts.update', { distributorCustomerId: dcId, contactId: editingDCContactId }), {
+                name: editingDCContactName.trim(),
+                type: editingDCContactType,
             });
-
-            if (response.ok) {
-                const data = await response.json();
-                setLocalDistributorCustomers(prev => prev.map(dc =>
-                    dc.id === dcId ? {
-                        ...dc,
-                        contacts: dc.contacts.map(c => c.id === editingDCContactId ? data.contact : c)
-                    } : dc
-                ));
-                setNotification({ type: 'success', message: 'Contact updated' });
-                cancelEditingDCContact();
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to update contact' });
-            }
+            setLocalDistributorCustomers(prev => prev.map(dc =>
+                dc.id === dcId ? {
+                    ...dc,
+                    contacts: dc.contacts.map(c => c.id === editingDCContactId ? response.data.contact : c)
+                } : dc
+            ));
+            setNotification({ type: 'success', message: 'Contact updated' });
+            cancelEditingDCContact();
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to update contact' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to update contact' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to update contact' });
+            }
         } finally {
             setSavingDCContact(false);
         }
@@ -1279,24 +1162,17 @@ export default function Show({
     const deleteDistributorCustomerContact = async (dcId: number, contactId: number) => {
         setDeletingDCContactId(contactId);
         try {
-            const response = await fetch(route('distributor-customers.contacts.delete', { distributorCustomerId: dcId, contactId }), {
-                method: 'DELETE',
-                headers: {
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-            });
-
-            if (response.ok) {
-                setLocalDistributorCustomers(prev => prev.map(dc =>
-                    dc.id === dcId ? { ...dc, contacts: dc.contacts.filter(c => c.id !== contactId) } : dc
-                ));
-                setNotification({ type: 'success', message: 'Contact deleted' });
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to delete contact' });
-            }
+            await axios.delete(route('distributor-customers.contacts.delete', { distributorCustomerId: dcId, contactId }));
+            setLocalDistributorCustomers(prev => prev.map(dc =>
+                dc.id === dcId ? { ...dc, contacts: dc.contacts.filter(c => c.id !== contactId) } : dc
+            ));
+            setNotification({ type: 'success', message: 'Contact deleted' });
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to delete contact' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to delete contact' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to delete contact' });
+            }
         } finally {
             setDeletingDCContactId(null);
         }
@@ -1327,27 +1203,18 @@ export default function Show({
     const saveCompanyUrls = async () => {
         setSaving(true);
         try {
-            const response = await fetch(route('customers.update-company-urls', customer.id), {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({
-                    company_urls: companyUrlsForm.filter(url => url.trim() !== ''),
-                }),
+            await axios.put(route('customers.update-company-urls', customer.id), {
+                company_urls: companyUrlsForm.filter(url => url.trim() !== ''),
             });
-
-            if (response.ok) {
-                setEditingCompanyUrls(false);
-                setNotification({ type: 'success', message: 'Company domains updated successfully' });
-                router.reload({ only: ['customer'] });
-            } else {
-                const data = await response.json();
-                setNotification({ type: 'error', message: data.message || 'Failed to save changes' });
-            }
+            setEditingCompanyUrls(false);
+            setNotification({ type: 'success', message: 'Company domains updated successfully' });
+            router.reload({ only: ['customer'] });
         } catch (error) {
-            setNotification({ type: 'error', message: 'Failed to save changes. Please try again.' });
+            if (axios.isAxiosError(error)) {
+                setNotification({ type: 'error', message: error.response?.data?.message || 'Failed to save changes' });
+            } else {
+                setNotification({ type: 'error', message: 'Failed to save changes. Please try again.' });
+            }
         } finally {
             setSaving(false);
         }

--- a/resources/js/Pages/Admin/EmailTemplates.tsx
+++ b/resources/js/Pages/Admin/EmailTemplates.tsx
@@ -1,5 +1,6 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { Head } from '@inertiajs/react';
+import axios from 'axios';
 import DOMPurify from 'dompurify';
 import { useState, useRef, useEffect } from 'react';
 
@@ -56,29 +57,20 @@ export default function EmailTemplates({ templates }: Props) {
         setNotification(null);
 
         try {
-            const response = await fetch(route('admin.email-templates.update', { key: selectedKey }), {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Accept': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({ subject, body }),
-            });
-
-            const data = await response.json();
-
-            if (response.ok) {
-                setNotification({ type: 'success', message: 'Template saved successfully' });
-            } else if (data.errors) {
-                // Laravel validation errors
-                const firstError = Object.values(data.errors).flat()[0] as string;
-                setNotification({ type: 'error', message: firstError || 'Validation failed' });
-            } else {
-                setNotification({ type: 'error', message: data.message || 'Failed to save template' });
-            }
+            await axios.put(route('admin.email-templates.update', { key: selectedKey }), { subject, body });
+            setNotification({ type: 'success', message: 'Template saved successfully' });
         } catch (error) {
-            setNotification({ type: 'error', message: 'An error occurred while saving' });
+            if (axios.isAxiosError(error)) {
+                const data = error.response?.data;
+                if (data?.errors) {
+                    const firstError = Object.values(data.errors).flat()[0] as string;
+                    setNotification({ type: 'error', message: firstError || 'Validation failed' });
+                } else {
+                    setNotification({ type: 'error', message: data?.message || 'Failed to save template' });
+                }
+            } else {
+                setNotification({ type: 'error', message: 'An error occurred while saving' });
+            }
         } finally {
             setSaving(false);
         }

--- a/resources/js/Pages/Admin/Settings.tsx
+++ b/resources/js/Pages/Admin/Settings.tsx
@@ -1,5 +1,6 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { Head, router } from '@inertiajs/react';
+import axios from 'axios';
 import { useState } from 'react';
 
 interface Props {
@@ -27,34 +28,26 @@ export default function Settings({ settings, testModeInfo, environment }: Props)
         setNotification(null);
 
         try {
-            const response = await fetch(route('admin.settings.update'), {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({ ar_test_mode: newValue }),
+            const response = await axios.put(route('admin.settings.update'), { ar_test_mode: newValue });
+            const data = response.data;
+
+            setTestMode(data.settings.ar_test_mode);
+            setNotification({
+                type: 'success',
+                message: `Test Mode ${data.settings.ar_test_mode ? 'enabled' : 'disabled'} successfully`,
             });
-
-            const data = await response.json();
-
-            if (response.ok) {
-                setTestMode(data.settings.ar_test_mode);
+        } catch (error) {
+            if (axios.isAxiosError(error)) {
                 setNotification({
-                    type: 'success',
-                    message: `Test Mode ${data.settings.ar_test_mode ? 'enabled' : 'disabled'} successfully`,
+                    type: 'error',
+                    message: error.response?.data?.message || 'Failed to update settings',
                 });
             } else {
                 setNotification({
                     type: 'error',
-                    message: data.message || 'Failed to update settings',
+                    message: 'An error occurred while updating settings',
                 });
             }
-        } catch (error) {
-            setNotification({
-                type: 'error',
-                message: 'An error occurred while updating settings',
-            });
         } finally {
             setSaving(false);
         }

--- a/resources/js/Pages/Prospects/Show.tsx
+++ b/resources/js/Pages/Prospects/Show.tsx
@@ -1,6 +1,7 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import EmailActivityPanel from '@/Components/EmailActivityPanel';
 import { Head, Link, router } from '@inertiajs/react';
+import axios from 'axios';
 import { useState, useEffect } from 'react';
 
 interface Contact {
@@ -372,27 +373,18 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
     const saveCompanyUrls = async () => {
         setSaving(true);
         try {
-            const response = await fetch(route('prospects.update', prospect.id), {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({
-                    company_urls: companyUrlsForm.filter(url => url.trim() !== ''),
-                }),
+            await axios.put(route('prospects.update', prospect.id), {
+                company_urls: companyUrlsForm.filter(url => url.trim() !== ''),
             });
-
-            if (response.ok) {
-                setEditingCompanyUrls(false);
-                setNewCompanyUrl('');
-                router.reload({ only: ['prospect'] });
+            setEditingCompanyUrls(false);
+            setNewCompanyUrl('');
+            router.reload({ only: ['prospect'] });
+        } catch (error) {
+            if (axios.isAxiosError(error)) {
+                alert(error.response?.data?.message || 'Failed to save changes');
             } else {
-                const data = await response.json();
-                alert(data.message || 'Failed to save changes');
+                alert('An error occurred while saving.');
             }
-        } catch {
-            alert('An error occurred while saving.');
         } finally {
             setSaving(false);
         }
@@ -401,23 +393,14 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
     const handleStatusChange = async (newStatus: string) => {
         setSaving(true);
         try {
-            const response = await fetch(`/prospects/${prospect.id}/status`, {
-                method: 'PATCH',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({ status: newStatus }),
-            });
-
-            if (response.ok) {
-                router.reload({ only: ['prospect'] });
+            await axios.patch(`/prospects/${prospect.id}/status`, { status: newStatus });
+            router.reload({ only: ['prospect'] });
+        } catch (error) {
+            if (axios.isAxiosError(error)) {
+                alert(error.response?.data?.message || 'Failed to update status');
             } else {
-                const data = await response.json();
-                alert(data.message || 'Failed to update status');
+                alert('An error occurred while updating status.');
             }
-        } catch {
-            alert('An error occurred while updating status.');
         } finally {
             setSaving(false);
         }
@@ -457,37 +440,28 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
 
         setSaving(true);
         try {
-            const response = await fetch(route('prospects.update', prospect.id), {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({
-                    company_name: detailsForm.company_name,
-                    discount_percent: selectedPriceList?.discount_percent ?? null,
-                    payment_terms: selectedPaymentTerm?.name || null,
-                    shipping_terms: selectedShippingTerm?.name || null,
-                    shelf_life_requirement: detailsForm.shelf_life_requirement ? parseInt(detailsForm.shelf_life_requirement) : null,
-                    vendor_guide: detailsForm.vendor_guide || null,
-                    broker: detailsForm.broker === 'true',
-                    customer_type: detailsForm.customer_type || null,
-                    ar_edi: detailsForm.ar_edi,
-                    ar_consolidated_invoicing: detailsForm.ar_consolidated_invoicing,
-                    ar_requires_customer_skus: detailsForm.ar_requires_customer_skus,
-                    ar_invoice_discount: detailsForm.ar_invoice_discount ? parseFloat(detailsForm.ar_invoice_discount) : null,
-                }),
+            await axios.put(route('prospects.update', prospect.id), {
+                company_name: detailsForm.company_name,
+                discount_percent: selectedPriceList?.discount_percent ?? null,
+                payment_terms: selectedPaymentTerm?.name || null,
+                shipping_terms: selectedShippingTerm?.name || null,
+                shelf_life_requirement: detailsForm.shelf_life_requirement ? parseInt(detailsForm.shelf_life_requirement) : null,
+                vendor_guide: detailsForm.vendor_guide || null,
+                broker: detailsForm.broker === 'true',
+                customer_type: detailsForm.customer_type || null,
+                ar_edi: detailsForm.ar_edi,
+                ar_consolidated_invoicing: detailsForm.ar_consolidated_invoicing,
+                ar_requires_customer_skus: detailsForm.ar_requires_customer_skus,
+                ar_invoice_discount: detailsForm.ar_invoice_discount ? parseFloat(detailsForm.ar_invoice_discount) : null,
             });
-
-            if (response.ok) {
-                setEditingDetails(false);
-                router.reload({ only: ['prospect'] });
-            } else {
-                const data = await response.json();
-                alert(data.message || 'Failed to save changes');
-            }
+            setEditingDetails(false);
+            router.reload({ only: ['prospect'] });
         } catch (error) {
-            alert('Failed to save changes');
+            if (axios.isAxiosError(error)) {
+                alert(error.response?.data?.message || 'Failed to save changes');
+            } else {
+                alert('Failed to save changes');
+            }
         } finally {
             setSaving(false);
         }
@@ -511,34 +485,25 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
             }
             // If ap_method is '', send empty array
 
-            const response = await fetch(route('prospects.update', prospect.id), {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({
-                    buyers: cleanContacts(contactsForm.buyers),
-                    accounts_payable: accountsPayable,
-                    other: contactsForm.other.filter(c => c.name.trim()).map(c => ({
-                        name: c.name.trim(),
-                        value: c.value?.trim() || '',
-                        function: c.function?.trim() || '',
-                    })),
-                    uncategorized: cleanContacts(contactsForm.uncategorized),
-                }),
+            await axios.put(route('prospects.update', prospect.id), {
+                buyers: cleanContacts(contactsForm.buyers),
+                accounts_payable: accountsPayable,
+                other: contactsForm.other.filter(c => c.name.trim()).map(c => ({
+                    name: c.name.trim(),
+                    value: c.value?.trim() || '',
+                    function: c.function?.trim() || '',
+                })),
+                uncategorized: cleanContacts(contactsForm.uncategorized),
             });
-
-            if (response.ok) {
-                setEditingContacts(false);
-                setCategorizingContacts({});
-                router.reload({ only: ['prospect'] });
-            } else {
-                const data = await response.json();
-                alert(data.message || 'Failed to save changes');
-            }
+            setEditingContacts(false);
+            setCategorizingContacts({});
+            router.reload({ only: ['prospect'] });
         } catch (error) {
-            alert('Failed to save changes');
+            if (axios.isAxiosError(error)) {
+                alert(error.response?.data?.message || 'Failed to save changes');
+            } else {
+                alert('Failed to save changes');
+            }
         } finally {
             setSaving(false);
         }
@@ -547,28 +512,19 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
     const saveProducts = async () => {
         setSaving(true);
         try {
-            const response = await fetch(route('prospects.update', prospect.id), {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({
-                    product_ids: productsForm.product_ids,
-                }),
+            await axios.put(route('prospects.update', prospect.id), {
+                product_ids: productsForm.product_ids,
             });
-
-            if (response.ok) {
-                setEditingProducts(false);
-                setProductSearch('');
-                setShowProductDropdown(false);
-                router.reload({ only: ['prospect'] });
-            } else {
-                const data = await response.json();
-                alert(data.message || 'Failed to save changes');
-            }
+            setEditingProducts(false);
+            setProductSearch('');
+            setShowProductDropdown(false);
+            router.reload({ only: ['prospect'] });
         } catch (error) {
-            alert('Failed to save changes');
+            if (axios.isAxiosError(error)) {
+                alert(error.response?.data?.message || 'Failed to save changes');
+            } else {
+                alert('Failed to save changes');
+            }
         } finally {
             setSaving(false);
         }
@@ -667,24 +623,15 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
         if (!contactId || !newType) return;
 
         try {
-            const response = await fetch(route('prospects.contacts.categorize', { prospectId: prospect.id, contactId }), {
-                method: 'PATCH',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({ type: newType }),
-            });
-
-            if (response.ok) {
-                setCategorizingContacts({});
-                router.reload({ only: ['prospect'] });
-            } else {
-                const data = await response.json();
-                alert(data.message || 'Failed to categorize contact');
-            }
+            await axios.patch(route('prospects.contacts.categorize', { prospectId: prospect.id, contactId }), { type: newType });
+            setCategorizingContacts({});
+            router.reload({ only: ['prospect'] });
         } catch (error) {
-            alert('Failed to categorize contact');
+            if (axios.isAxiosError(error)) {
+                alert(error.response?.data?.message || 'Failed to categorize contact');
+            } else {
+                alert('Failed to categorize contact');
+            }
         }
     };
 
@@ -726,29 +673,20 @@ export default function Show({ prospect, statuses, allProducts, priceLists, paym
             const cleanContacts = (contacts: BrokerContact[]) =>
                 contacts.filter(c => c.name).map(c => ({ name: c.name, value: c.value || '' }));
 
-            const response = await fetch(route('prospects.update', prospect.id), {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
-                },
-                body: JSON.stringify({
-                    broker: detailsForm.broker === 'true',
-                    broker_commission: detailsForm.broker_commission ? parseFloat(detailsForm.broker_commission) : null,
-                    broker_company_name: detailsForm.broker_company_name || null,
-                    broker_contacts: cleanContacts(brokerContactsForm.broker_contacts),
-                }),
+            await axios.put(route('prospects.update', prospect.id), {
+                broker: detailsForm.broker === 'true',
+                broker_commission: detailsForm.broker_commission ? parseFloat(detailsForm.broker_commission) : null,
+                broker_company_name: detailsForm.broker_company_name || null,
+                broker_contacts: cleanContacts(brokerContactsForm.broker_contacts),
             });
-
-            if (response.ok) {
-                setEditingBroker(false);
-                router.reload({ only: ['prospect'] });
-            } else {
-                const data = await response.json();
-                alert(data.message || 'Failed to save broker settings');
-            }
+            setEditingBroker(false);
+            router.reload({ only: ['prospect'] });
         } catch (error) {
-            alert('Failed to save broker settings');
+            if (axios.isAxiosError(error)) {
+                alert(error.response?.data?.message || 'Failed to save broker settings');
+            } else {
+                alert('Failed to save broker settings');
+            }
         } finally {
             setSaving(false);
         }


### PR DESCRIPTION
Status: let's wait until https://github.com/UniversalYumsLLC/sales/pull/28 is merged, because the existing issues that solved in that PR are currently affecting the testing of this.
Once that PR is merged we can merge main into this branch and finish the work.

----

Closes #29

## Summary

- Replaces all 30 remaining `fetch()` GET/POST/PUT/PATCH/DELETE requests with `axios`, completing the migration to the project's standard HTTP client
- Removes manual CSRF token extraction from every request — axios handles this automatically via `bootstrap.ts`
- Updates error handling to use `axios.isAxiosError()` patterns
- No `fetch()` calls remain in `resources/js/`

Mirrors [pim PR #236](https://github.com/UniversalYumsLLC/pim/pull/236).

**Files changed:**
- `EmailActivityPanel.tsx` — email list endpoint (GET)
- `EmailDetailModal.tsx` — email detail endpoint (GET)
- `AccountsReceivable/Index.tsx` — PDF regeneration, email resend (POST)
- `ActiveCustomers/Show.tsx` — all customer CRUD operations (17 calls)
- `Prospects/Show.tsx` — all prospect CRUD operations (7 calls)
- `Admin/Settings.tsx` — test mode toggle (PUT)
- `Admin/EmailTemplates.tsx` — template save (PUT)

## Test plan

### Prospects (`/prospects/{id}`)
- [ ] Edit company domains and save — verify changes persist after reload
- [ ] Change prospect status via the status dropdown — verify it updates
- [ ] Edit and save prospect details (company name, discount, payment terms, etc.)
- [ ] Edit and save contacts (buyers, AP inbox/portal, other, uncategorized)
- [ ] Edit and save products — add/remove products from the prospect
- [ ] Categorize an uncategorized contact into buyer/AP/other
- [ ] Edit and save broker settings (toggle broker, commission, contacts)

### Active Customers (`/customers/{id}`)
- [ ] Edit and save customer details (name, discount, payment terms, shelf life, vendor guide, AR settings)
- [ ] Edit and save contacts (buyers, AP inbox/portal, other)
- [ ] Add a new customer SKU mapping and verify it appears in the list
- [ ] Delete a customer SKU mapping and verify it disappears
- [ ] Click "Regenerate PDF" on an invoice and verify the PDF downloads
- [ ] Categorize an uncategorized local contact into buyer/AP/other
- [ ] Delete a local contact
- [ ] Edit and save broker settings (toggle broker, commission, company name, contacts)
- [ ] Change customer type between retailer and distributor
- [ ] Add a new distributor customer and verify it appears
- [ ] Delete a distributor customer
- [ ] Edit a distributor customer's name and domains
- [ ] Update a distributor customer's domains via the inline URL editor
- [ ] Add a contact to a distributor customer
- [ ] Edit a distributor customer contact's name and type
- [ ] Delete a distributor customer contact
- [ ] Edit and save company domains

### Accounts Receivable (`/ar`)
- [ ] Click "Regenerate PDF" on an invoice row — verify success message and PDF opens
- [ ] Resend an email for an invoice via the dropdown — verify success message

### Email Activity (panel on Prospect and Customer pages)
- [ ] Open a prospect or customer page and verify the email list loads in the activity panel
- [ ] Click "Load more" if available and verify additional emails append
- [ ] Click an email in the list and verify the detail modal opens with full content

### Admin Settings (`/admin/settings`)
- [ ] Toggle the AR Test Mode switch — verify success notification and toggle state updates

### Email Templates (`/admin/email-templates`)
- [ ] Select a template, edit subject/body, and save — verify success notification
- [ ] Try saving with invalid data and verify validation error appears