### PR TITLE
Fix invoice PDF download failing on missing requires_customer_skus

### DIFF
--- a/app/Services/InvoicePdfService.php
+++ b/app/Services/InvoicePdfService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\DTOs\Invoice\InvoicePdfDto;
 use App\Exceptions\InvoicePdfException;
 use App\Models\CustomerSku;
+use App\Models\LocalCustomerMetadata;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
@@ -47,11 +48,13 @@ class InvoicePdfService
             return $pdfPath;
         }
 
-        // Check customer AR settings (SKU requirements, discount)
+        // Check customer AR settings (SKU requirements from local DB, discount from Fulfil)
+        $localMetadata = LocalCustomerMetadata::find($dto->customerId);
+        $requiresCustomerSkus = $localMetadata?->ar_requires_customer_skus ?? false;
         $arSettings = $this->fulfil->getCustomerArSettings($dto->customerId);
         $hasCustomerSkus = false;
 
-        if ($arSettings['requires_customer_skus']) {
+        if ($requiresCustomerSkus) {
             // Validate that all SKUs are mapped
             $productCodes = $dto->getProductCodes();
             $unmappedSkus = CustomerSku::getUnmappedSkus($dto->customerId, $productCodes);

--- a/tests/Unit/Services/InvoicePdfServiceTest.php
+++ b/tests/Unit/Services/InvoicePdfServiceTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use App\Models\CustomerSku;
+use App\Models\LocalCustomerMetadata;
+use App\Services\FulfilService;
+use App\Services\InvoicePdfService;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Minimal Fulfil invoice data for InvoicePdfDto::fromFulfil().
+ */
+function fakeFulfilInvoiceData(int $partyId): array
+{
+    return [
+        'number' => 'INV-99999',
+        'invoice_date' => '2026-01-15',
+        'due_date' => '2026-02-15',
+        'state' => 'posted',
+        'reference' => null,
+        'total_amount' => 100.00,
+        'balance' => 100.00,
+        'balance_due' => 100.00,
+        'invoice_address' => [
+            'name' => 'Test Co',
+            'street' => '123 Main St',
+            'city' => 'Springfield',
+            'subdivision_code' => 'IL',
+            'zip' => '62704',
+            'country_code' => 'US',
+        ],
+        'customer_shipments' => [],
+        'sales_person_name' => 'Sales Rep',
+        'payment_term_name' => 'Net 30',
+        'order_number' => 'SO-001',
+        'party_id' => $partyId,
+        'lines' => [
+            [
+                'description' => 'Yums Box',
+                'product_code' => 'YUMS-001',
+                'account_code' => '400',
+                'quantity' => 10,
+                'unit_price' => 10.00,
+                'amount' => 100.00,
+            ],
+        ],
+    ];
+}
+
+test('generate reads requires_customer_skus from local metadata, not Fulfil', function () {
+    Storage::fake('local');
+
+    $metadata = LocalCustomerMetadata::factory()->create([
+        'ar_requires_customer_skus' => true,
+    ]);
+
+    // Map the SKU so generation succeeds (no unmapped SKU exception)
+    CustomerSku::create([
+        'fulfil_party_id' => $metadata->fulfil_party_id,
+        'yums_sku' => 'YUMS-001',
+        'customer_sku' => 'CUST-001',
+    ]);
+
+    $fulfilMock = Mockery::mock(FulfilService::class);
+    $fulfilMock->shouldReceive('getInvoiceForPdf')
+        ->andReturn(fakeFulfilInvoiceData($metadata->fulfil_party_id));
+    // getCustomerArSettings does NOT return requires_customer_skus (matches production)
+    $fulfilMock->shouldReceive('getCustomerArSettings')
+        ->andReturn(['invoice_discount' => null]);
+
+    $service = new InvoicePdfService($fulfilMock);
+    $path = $service->generate(12345);
+
+    expect($path)->toContain('INV-99999.pdf');
+    Storage::disk('local')->assertExists($path);
+});
+
+test('generate works when local metadata has requires_customer_skus false', function () {
+    Storage::fake('local');
+
+    $metadata = LocalCustomerMetadata::factory()->create([
+        'ar_requires_customer_skus' => false,
+    ]);
+
+    $fulfilMock = Mockery::mock(FulfilService::class);
+    $fulfilMock->shouldReceive('getInvoiceForPdf')
+        ->andReturn(fakeFulfilInvoiceData($metadata->fulfil_party_id));
+    $fulfilMock->shouldReceive('getCustomerArSettings')
+        ->andReturn(['invoice_discount' => null]);
+
+    $service = new InvoicePdfService($fulfilMock);
+    $path = $service->generate(12345);
+
+    expect($path)->toContain('INV-99999.pdf');
+    Storage::disk('local')->assertExists($path);
+});
+
+test('generate works when no local metadata exists for customer', function () {
+    Storage::fake('local');
+
+    $fulfilMock = Mockery::mock(FulfilService::class);
+    $fulfilMock->shouldReceive('getInvoiceForPdf')
+        ->andReturn(fakeFulfilInvoiceData(999999));
+    $fulfilMock->shouldReceive('getCustomerArSettings')
+        ->andReturn(['invoice_discount' => null]);
+
+    $service = new InvoicePdfService($fulfilMock);
+    $path = $service->generate(12345);
+
+    expect($path)->toContain('INV-99999.pdf');
+    Storage::disk('local')->assertExists($path);
+});


### PR DESCRIPTION
### Which issue does this close?

Closes #40

### Write a short description of code change.

- `InvoicePdfService::generate()` was accessing `$arSettings['requires_customer_skus']` from `FulfilService::getCustomerArSettings()`, but that method no longer returns it after the migration to the local database. Now reads it from `LocalCustomerMetadata`, matching the pattern in `ArAutomationService`.
- Added 3 unit tests for `InvoicePdfService::generate()` covering: flag enabled with mapped SKUs, flag disabled, and missing metadata record.

### How should these changes be tested?

- [ ] Go to a customer page (e.g. `/customers/571620`) and click to download an invoice PDF — should download without error.

### Steps taken before assigning the PR.

- [x] Reviewed the changeset in this PR.
- [x] Initial code review by Claude.