### PR TITLE
Add ESLint and Prettier caching to CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,15 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Restore Lint Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .eslintcache
+            .prettiercache
+          key: lint-cache-${{ github.sha }}
+          restore-keys: lint-cache-
+
       - name: Install Dependencies
         run: |
           composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist &
@@ -46,10 +55,10 @@ jobs:
         run: vendor/bin/pint --test --parallel
 
       - name: Format Check
-        run: npm run format:check
+        run: npx prettier --check --cache --cache-location .prettiercache resources/
 
       - name: Lint Frontend
-        run: npm run lint:check
+        run: npx eslint --cache --cache-location .eslintcache .
 
       - name: TypeScript Check
         run: npm run types

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,4 @@
+# CI lint workflow with caching
 name: linter
 
 on:


### PR DESCRIPTION
## Summary
- Adds `actions/cache` step to persist `.eslintcache` and `.prettiercache` between CI runs
- ESLint and Prettier now run with `--cache` flags, skipping unchanged files on subsequent runs

## Test plan
- [ ] Verify first CI run passes (full lint, cache gets saved)
- [ ] Verify subsequent CI run restores cache and completes faster